### PR TITLE
Add disable_post_quantum_key_agreement parameter to CreateSessionParams

### DIFF
--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -110,6 +110,9 @@ class SessionLaunchState(BaseModel):
     append_timestamp_to_downloads: Optional[bool] = Field(
         default=None, alias="appendTimestampToDownloads"
     )
+    disable_post_quantum_key_agreement: Optional[bool] = Field(
+        default=None, alias="disablePostQuantumKeyAgreement"
+    )
 
 
 class Session(BaseModel):

--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -334,6 +334,9 @@ class CreateSessionParams(BaseModel):
     """This option replaces native elements (say for dropdowns) with a custom dropdown.
     Use this option with caution, as this may cause unusual behavior in the browser.
     """
+    disable_post_quantum_key_agreement: Optional[bool] = Field(
+        default=None, serialization_alias="disablePostQuantumKeyAgreement"
+    )
 
 
 class SessionRecording(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.82.2"
+version = "0.82.3"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Added support for the `disable_post_quantum_key_agreement` parameter in the `CreateSessionParams` model to allow users to control post-quantum key agreement behavior during session creation.