### PR TITLE
fix file overwrite

### DIFF
--- a/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_files.py
+++ b/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_files.py
@@ -18,6 +18,7 @@ from .....models.sandbox import (
     SandboxFileCopyParams,
     SandboxFileDeleteParams,
     SandboxFileInfo,
+    SandboxFileMoveParams,
     SandboxFileReadResult,
     SandboxFileSystemEvent,
     SandboxFileWriteEntry,
@@ -461,14 +462,24 @@ class SandboxFilesApi:
     ) -> bool:
         return await self.make_dir(path, parents=parents, mode=mode)
 
-    async def rename(self, old_path: str, new_path: str) -> SandboxFileInfo:
+    async def rename(
+        self,
+        old_path: str,
+        new_path: str,
+        *,
+        overwrite: Optional[bool] = None,
+    ) -> SandboxFileInfo:
+        payload = SandboxFileMoveParams(
+            source=old_path,
+            destination=new_path,
+            overwrite=overwrite,
+        ).model_dump(exclude_none=True)
+        payload["from"] = payload.pop("source")
+        payload["to"] = payload.pop("destination")
         payload = await self._transport.request_json(
             "/sandbox/files/move",
             method="POST",
-            json_body={
-                "from": old_path,
-                "to": new_path,
-            },
+            json_body=payload,
             headers={"content-type": "application/json"},
         )
         return _normalize_file_info(payload["entry"])
@@ -480,7 +491,7 @@ class SandboxFilesApi:
         destination: str,
         overwrite: Optional[bool] = None,
     ) -> SandboxFileInfo:
-        return await self.rename(source, destination)
+        return await self.rename(source, destination, overwrite=overwrite)
 
     async def remove(self, path: str, *, recursive: Optional[bool] = None) -> None:
         await self._transport.request_json(

--- a/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_files.py
+++ b/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_files.py
@@ -17,6 +17,7 @@ from .....models.sandbox import (
     SandboxFileCopyParams,
     SandboxFileDeleteParams,
     SandboxFileInfo,
+    SandboxFileMoveParams,
     SandboxFileReadResult,
     SandboxFileSystemEvent,
     SandboxFileWriteEntry,
@@ -442,14 +443,24 @@ class SandboxFilesApi:
     ) -> bool:
         return self.make_dir(path, parents=parents, mode=mode)
 
-    def rename(self, old_path: str, new_path: str) -> SandboxFileInfo:
+    def rename(
+        self,
+        old_path: str,
+        new_path: str,
+        *,
+        overwrite: Optional[bool] = None,
+    ) -> SandboxFileInfo:
+        payload = SandboxFileMoveParams(
+            source=old_path,
+            destination=new_path,
+            overwrite=overwrite,
+        ).model_dump(exclude_none=True)
+        payload["from"] = payload.pop("source")
+        payload["to"] = payload.pop("destination")
         payload = self._transport.request_json(
             "/sandbox/files/move",
             method="POST",
-            json_body={
-                "from": old_path,
-                "to": new_path,
-            },
+            json_body=payload,
             headers={"content-type": "application/json"},
         )
         return _normalize_file_info(payload["entry"])
@@ -461,7 +472,7 @@ class SandboxFilesApi:
         destination: str,
         overwrite: Optional[bool] = None,
     ) -> SandboxFileInfo:
-        return self.rename(source, destination)
+        return self.rename(source, destination, overwrite=overwrite)
 
     def remove(self, path: str, *, recursive: Optional[bool] = None) -> None:
         self._transport.request_json(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.85.0"
+version = "0.86.0"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"

--- a/tests/sandbox/e2e/test_async_files.py
+++ b/tests/sandbox/e2e/test_async_files.py
@@ -327,6 +327,35 @@ async def test_async_sandbox_files_e2e():
         assert await sandbox.files.read_text(existing_target) == "existing target"
         assert (await sandbox.files.get_info(destination_link)).symlink_target is None
 
+        move_source = f"{base_dir}/move-overwrite/source.txt"
+        move_existing_target = f"{base_dir}/move-overwrite/existing-target.txt"
+        move_destination_link = f"{base_dir}/move-overwrite/destination-link.txt"
+        await sandbox.files.write_text(move_source, "move source payload")
+        await sandbox.files.write_text(move_existing_target, "move existing target")
+        result = await sandbox.exec(
+            _bash_exec(
+                f'mkdir -p "{base_dir}/move-overwrite" && ln -sfn "{move_existing_target}" "{move_destination_link}"'
+            )
+        )
+        assert result.exit_code == 0
+        await sandbox.files.move(
+            source=move_source,
+            destination=move_destination_link,
+            overwrite=True,
+        )
+        assert (
+            await sandbox.files.read_text(move_destination_link)
+            == "move source payload"
+        )
+        assert (
+            await sandbox.files.read_text(move_existing_target)
+            == "move existing target"
+        )
+        assert (
+            await sandbox.files.get_info(move_destination_link)
+        ).symlink_target is None
+        assert await sandbox.files.exists(move_source) is False
+
         chmod_path = f"{base_dir}/chmod/file.txt"
         await sandbox.files.write_text(chmod_path, "chmod me")
         await sandbox.files.chmod(path=chmod_path, mode="0640")

--- a/tests/sandbox/e2e/test_files.py
+++ b/tests/sandbox/e2e/test_files.py
@@ -294,6 +294,27 @@ def test_sandbox_files_e2e():
         assert sandbox.files.read_text(existing_target) == "existing target"
         assert sandbox.files.get_info(destination_link).symlink_target is None
 
+        move_source = f"{base_dir}/move-overwrite/source.txt"
+        move_existing_target = f"{base_dir}/move-overwrite/existing-target.txt"
+        move_destination_link = f"{base_dir}/move-overwrite/destination-link.txt"
+        sandbox.files.write_text(move_source, "move source payload")
+        sandbox.files.write_text(move_existing_target, "move existing target")
+        result = sandbox.exec(
+            _bash_exec(
+                f'mkdir -p "{base_dir}/move-overwrite" && ln -sfn "{move_existing_target}" "{move_destination_link}"'
+            )
+        )
+        assert result.exit_code == 0
+        sandbox.files.move(
+            source=move_source,
+            destination=move_destination_link,
+            overwrite=True,
+        )
+        assert sandbox.files.read_text(move_destination_link) == "move source payload"
+        assert sandbox.files.read_text(move_existing_target) == "move existing target"
+        assert sandbox.files.get_info(move_destination_link).symlink_target is None
+        assert sandbox.files.exists(move_source) is False
+
         chmod_path = f"{base_dir}/chmod/file.txt"
         sandbox.files.write_text(chmod_path, "chmod me")
         sandbox.files.chmod(path=chmod_path, mode="0640")

--- a/tests/test_sandbox_wire_contract.py
+++ b/tests/test_sandbox_wire_contract.py
@@ -1,0 +1,671 @@
+import httpx
+import pytest
+
+from hyperbrowser.client.managers.async_manager.sandbox import (
+    SandboxManager as AsyncSandboxManager,
+)
+from hyperbrowser.client.managers.async_manager.sandboxes.sandbox_files import (
+    SandboxFilesApi as AsyncSandboxFilesApi,
+)
+from hyperbrowser.client.managers.async_manager.sandboxes.sandbox_processes import (
+    SandboxProcessesApi as AsyncSandboxProcessesApi,
+)
+from hyperbrowser.client.managers.async_manager.sandboxes.sandbox_terminal import (
+    SandboxTerminalApi as AsyncSandboxTerminalApi,
+)
+from hyperbrowser.client.managers.sync_manager.sandbox import SandboxManager
+from hyperbrowser.client.managers.sync_manager.sandboxes.sandbox_files import (
+    SandboxFilesApi,
+)
+from hyperbrowser.client.managers.sync_manager.sandboxes.sandbox_processes import (
+    SandboxProcessesApi,
+)
+from hyperbrowser.client.managers.sync_manager.sandboxes.sandbox_terminal import (
+    SandboxTerminalApi,
+)
+from hyperbrowser.models import (
+    CreateSandboxParams,
+    SandboxExecParams,
+    SandboxMemorySnapshotParams,
+    SandboxPresignFileParams,
+    SandboxProcessListParams,
+    SandboxProcessWaitParams,
+    SandboxTerminalCreateParams,
+    SandboxTerminalKillParams,
+    SandboxTerminalWaitParams,
+)
+
+
+SANDBOX_DETAIL_PAYLOAD = {
+    "id": "sbx_123",
+    "teamId": "team_1",
+    "status": "active",
+    "endTime": None,
+    "startTime": 123,
+    "createdAt": "2026-03-12T00:00:00Z",
+    "updatedAt": "2026-03-12T00:00:01Z",
+    "closeReason": None,
+    "dataConsumed": 1,
+    "proxyDataConsumed": 2,
+    "usageType": "sandbox",
+    "jobId": None,
+    "launchState": None,
+    "creditsUsed": 0.1,
+    "region": "us",
+    "sessionUrl": "https://example.com/session",
+    "duration": 10,
+    "proxyBytesUsed": 3,
+    "runtime": {
+        "transport": "regional_proxy",
+        "host": "runtime.example.com",
+        "baseUrl": "https://runtime.example.com",
+    },
+    "token": "tok",
+    "tokenExpiresAt": "2026-03-12T01:00:00Z",
+}
+
+SNAPSHOT_RESULT_PAYLOAD = {
+    "snapshotName": "snap",
+    "snapshotId": "sid",
+    "namespace": "ns",
+    "status": "ready",
+    "imageName": "img",
+    "imageId": "iid",
+    "imageNamespace": "ins",
+}
+
+PROCESS_RESULT_PAYLOAD = {
+    "result": {
+        "id": "proc_1",
+        "status": "exited",
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": "",
+        "started_at": 1,
+        "completed_at": 2,
+        "error": None,
+    }
+}
+
+PROCESS_SUMMARY_PAYLOAD = {
+    "process": {
+        "id": "proc_1",
+        "status": "running",
+        "command": "bash",
+        "args": ["-lc", "echo hi"],
+        "cwd": "/tmp",
+        "pid": 123,
+        "exit_code": None,
+        "started_at": 1,
+        "completed_at": None,
+    }
+}
+
+PROCESS_LIST_PAYLOAD = {
+    "data": [],
+    "next_cursor": None,
+}
+
+PTY_PAYLOAD = {
+    "pty": {
+        "id": "pty_1",
+        "command": "bash",
+        "args": ["-lc"],
+        "cwd": "/tmp",
+        "pid": 321,
+        "running": True,
+        "exitCode": None,
+        "error": None,
+        "timedOut": False,
+        "rows": 24,
+        "cols": 80,
+        "startedAt": 1,
+        "finishedAt": None,
+        "output": [],
+    }
+}
+
+WATCH_PAYLOAD = {
+    "watch": {
+        "id": "watch_1",
+        "path": "/tmp",
+        "recursive": False,
+        "active": True,
+        "error": None,
+        "createdAt": 1,
+        "stoppedAt": None,
+        "oldestSeq": 0,
+        "lastSeq": 0,
+        "eventCount": 0,
+    }
+}
+
+UPLOAD_PRESIGN_PAYLOAD = {
+    "token": "upload-token",
+    "path": "/tmp/file.txt",
+    "method": "PUT",
+    "expiresAt": 123,
+    "url": "https://example.com/upload",
+}
+
+DOWNLOAD_PRESIGN_PAYLOAD = {
+    "token": "download-token",
+    "path": "/tmp/file.txt",
+    "method": "GET",
+    "expiresAt": 123,
+    "url": "https://example.com/download",
+}
+
+MOVE_FILE_PAYLOAD = {
+    "entry": {
+        "path": "/tmp/destination.txt",
+        "name": "destination.txt",
+        "type": "file",
+        "size": 14,
+        "mode": 420,
+        "permissions": "-rw-r--r--",
+        "owner": "root",
+        "group": "root",
+        "modifiedTime": 123,
+        "symlinkTarget": None,
+    }
+}
+
+
+class RecordingHTTPClient:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, params=None, json=None):
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "params": params,
+                "json": json,
+            }
+        )
+
+        if url.endswith("/sandbox"):
+            payload = SANDBOX_DETAIL_PAYLOAD
+        elif url.endswith("/snapshot"):
+            payload = SNAPSHOT_RESULT_PAYLOAD
+        else:
+            payload = {}
+
+        return httpx.Response(
+            200,
+            json=payload,
+            request=httpx.Request(method, url),
+        )
+
+
+class RecordingTransport:
+    def __init__(self):
+        self.calls = []
+
+    def request_json(
+        self,
+        path,
+        *,
+        method="GET",
+        params=None,
+        json_body=None,
+        content=None,
+        headers=None,
+    ):
+        self.calls.append(
+            {
+                "path": path,
+                "method": method,
+                "params": params,
+                "json_body": json_body,
+                "content": content,
+                "headers": headers,
+            }
+        )
+
+        if path == "/sandbox/exec":
+            return PROCESS_RESULT_PAYLOAD
+        if path == "/sandbox/processes" and method == "POST":
+            return PROCESS_SUMMARY_PAYLOAD
+        if path == "/sandbox/processes":
+            return PROCESS_LIST_PAYLOAD
+        if path.endswith("/wait") and "/sandbox/processes/" in path:
+            return PROCESS_RESULT_PAYLOAD
+        if path == "/sandbox/pty" or path.startswith("/sandbox/pty/"):
+            return PTY_PAYLOAD
+        if path.startswith("/sandbox/files/watch/"):
+            return WATCH_PAYLOAD
+        if path == "/sandbox/files/presign-upload":
+            return UPLOAD_PRESIGN_PAYLOAD
+        if path == "/sandbox/files/presign-download":
+            return DOWNLOAD_PRESIGN_PAYLOAD
+        if path == "/sandbox/files/move":
+            return MOVE_FILE_PAYLOAD
+        raise AssertionError(f"Unexpected request path: {path}")
+
+
+class AsyncRecordingTransport(RecordingTransport):
+    async def request_json(
+        self,
+        path,
+        *,
+        method="GET",
+        params=None,
+        json_body=None,
+        content=None,
+        headers=None,
+    ):
+        return super().request_json(
+            path,
+            method=method,
+            params=params,
+            json_body=json_body,
+            content=content,
+            headers=headers,
+        )
+
+
+class FakeSyncClient:
+    def __init__(self):
+        http_client = RecordingHTTPClient()
+        self.transport = type("Transport", (), {"client": http_client})()
+        self.config = type("Config", (), {"runtime_proxy_override": None})()
+        self.timeout = 30
+
+    def _build_url(self, path: str) -> str:
+        return f"https://api.example.com{path}"
+
+
+class RecordingAsyncHTTPClient:
+    def __init__(self):
+        self.calls = []
+
+    async def request(self, method, url, params=None, json=None):
+        self.calls.append(
+            {
+                "method": method,
+                "url": url,
+                "params": params,
+                "json": json,
+            }
+        )
+
+        if url.endswith("/sandbox"):
+            payload = SANDBOX_DETAIL_PAYLOAD
+        elif url.endswith("/snapshot"):
+            payload = SNAPSHOT_RESULT_PAYLOAD
+        else:
+            payload = {}
+
+        return httpx.Response(
+            200,
+            json=payload,
+            request=httpx.Request(method, url),
+        )
+
+
+class FakeAsyncClient:
+    def __init__(self):
+        http_client = RecordingAsyncHTTPClient()
+        self.transport = type("Transport", (), {"client": http_client})()
+        self.config = type("Config", (), {"runtime_proxy_override": None})()
+        self.timeout = 30
+
+    def _build_url(self, path: str) -> str:
+        return f"https://api.example.com{path}"
+
+
+def test_sandbox_request_models_serialize_expected_wire_keys():
+    assert CreateSandboxParams(
+        image_name="node",
+        image_id="img-id",
+        enable_recording=True,
+        timeout_minutes=15,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "imageName": "node",
+        "imageId": "img-id",
+        "enableRecording": True,
+        "timeoutMinutes": 15,
+    }
+
+    assert SandboxMemorySnapshotParams(snapshot_name="snap").model_dump(
+        by_alias=True, exclude_none=True
+    ) == {
+        "snapshotName": "snap",
+    }
+
+    assert SandboxExecParams(
+        command="echo hi",
+        timeout_ms=500,
+        timeout_sec=7,
+        use_shell=True,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "command": "echo hi",
+        "timeoutMs": 500,
+        "timeout_sec": 7,
+        "useShell": True,
+    }
+
+    assert SandboxProcessWaitParams(
+        timeout_ms=250,
+        timeout_sec=3,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "timeoutMs": 250,
+        "timeout_sec": 3,
+    }
+
+    assert SandboxProcessListParams(
+        status=["running", "exited"],
+        limit=10,
+        cursor="cursor-1",
+        created_after=100,
+        created_before=200,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "status": ["running", "exited"],
+        "limit": 10,
+        "cursor": "cursor-1",
+        "created_after": 100,
+        "created_before": 200,
+    }
+
+    assert SandboxPresignFileParams(
+        path="/tmp/file.txt",
+        expires_in_seconds=60,
+        one_time=True,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "path": "/tmp/file.txt",
+        "expiresInSeconds": 60,
+        "oneTime": True,
+    }
+
+    assert SandboxTerminalCreateParams(
+        command="bash",
+        use_shell=False,
+        rows=24,
+        cols=80,
+        timeout_ms=1500,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "command": "bash",
+        "useShell": False,
+        "rows": 24,
+        "cols": 80,
+        "timeoutMs": 1500,
+    }
+
+    assert SandboxTerminalWaitParams(
+        timeout_ms=800,
+        include_output=True,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "timeoutMs": 800,
+        "includeOutput": True,
+    }
+
+    assert SandboxTerminalKillParams(
+        signal="TERM",
+        timeout_ms=900,
+    ).model_dump(by_alias=True, exclude_none=True) == {
+        "signal": "TERM",
+        "timeoutMs": 900,
+    }
+
+
+def test_sync_sandbox_control_manager_uses_expected_wire_keys():
+    client = FakeSyncClient()
+    manager = SandboxManager(client)
+
+    manager.create(
+        CreateSandboxParams(
+            image_name="node",
+            image_id="img-id",
+            enable_recording=True,
+            timeout_minutes=15,
+        )
+    )
+    manager.create_memory_snapshot(
+        "sbx_123",
+        SandboxMemorySnapshotParams(snapshot_name="snap"),
+    )
+
+    create_call = client.transport.client.calls[0]
+    snapshot_call = client.transport.client.calls[1]
+
+    assert create_call["json"] == {
+        "imageName": "node",
+        "imageId": "img-id",
+        "enableRecording": True,
+        "timeoutMinutes": 15,
+    }
+    assert snapshot_call["json"] == {
+        "snapshotName": "snap",
+    }
+
+
+def test_sync_sandbox_runtime_apis_use_expected_wire_keys():
+    transport = RecordingTransport()
+
+    processes = SandboxProcessesApi(transport)
+    process_input = SandboxExecParams(
+        command="echo hi",
+        timeout_ms=500,
+        timeout_sec=7,
+        use_shell=True,
+    )
+
+    processes.exec(process_input)
+    handle = processes.start(process_input)
+    handle.wait(timeout_ms=250, timeout_sec=3)
+    processes.list(
+        status=["running", "exited"],
+        limit=10,
+        cursor="cursor-1",
+        created_after=100,
+        created_before=200,
+    )
+
+    terminal = SandboxTerminalApi(transport, lambda: None)
+    terminal_handle = terminal.create(
+        SandboxTerminalCreateParams(
+            command="bash",
+            use_shell=False,
+            rows=24,
+            cols=80,
+            timeout_ms=1500,
+        )
+    )
+    terminal.get("pty_1", include_output=True)
+    terminal_handle.wait(timeout_ms=800, include_output=True)
+
+    files = SandboxFilesApi(transport, lambda: None)
+    files.get_watch("watch_1", include_events=True)
+    files.upload_url("/tmp/file.txt", expires_in_seconds=60, one_time=True)
+    files.download_url("/tmp/file.txt", expires_in_seconds=30, one_time=False)
+    files.move(
+        source="/tmp/source.txt",
+        destination="/tmp/destination.txt",
+        overwrite=True,
+    )
+
+    assert transport.calls[0]["json_body"] == {
+        "command": "echo hi",
+        "timeoutMs": 500,
+        "timeout_sec": 7,
+        "useShell": True,
+    }
+    assert transport.calls[1]["json_body"] == {
+        "command": "echo hi",
+        "timeoutMs": 500,
+        "timeout_sec": 7,
+        "useShell": True,
+    }
+    assert transport.calls[2]["json_body"] == {
+        "timeoutMs": 250,
+        "timeout_sec": 3,
+    }
+    assert transport.calls[3]["params"] == {
+        "status": "running,exited",
+        "limit": 10,
+        "cursor": "cursor-1",
+        "created_after": 100,
+        "created_before": 200,
+    }
+    assert transport.calls[4]["json_body"] == {
+        "command": "bash",
+        "useShell": False,
+        "rows": 24,
+        "cols": 80,
+        "timeoutMs": 1500,
+    }
+    assert transport.calls[5]["params"] == {"includeOutput": True}
+    assert transport.calls[6]["json_body"] == {
+        "timeoutMs": 800,
+        "includeOutput": True,
+    }
+    assert transport.calls[7]["params"] == {"includeEvents": True}
+    assert transport.calls[8]["json_body"] == {
+        "path": "/tmp/file.txt",
+        "expiresInSeconds": 60,
+        "oneTime": True,
+    }
+    assert transport.calls[9]["json_body"] == {
+        "path": "/tmp/file.txt",
+        "expiresInSeconds": 30,
+        "oneTime": False,
+    }
+    assert transport.calls[10]["json_body"] == {
+        "from": "/tmp/source.txt",
+        "to": "/tmp/destination.txt",
+        "overwrite": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_async_sandbox_control_manager_uses_expected_wire_keys():
+    client = FakeAsyncClient()
+    manager = AsyncSandboxManager(client)
+
+    await manager.create(
+        CreateSandboxParams(
+            image_name="node",
+            image_id="img-id",
+            enable_recording=True,
+            timeout_minutes=15,
+        )
+    )
+    await manager.create_memory_snapshot(
+        "sbx_123",
+        SandboxMemorySnapshotParams(snapshot_name="snap"),
+    )
+
+    create_call = client.transport.client.calls[0]
+    snapshot_call = client.transport.client.calls[1]
+
+    assert create_call["json"] == {
+        "imageName": "node",
+        "imageId": "img-id",
+        "enableRecording": True,
+        "timeoutMinutes": 15,
+    }
+    assert snapshot_call["json"] == {
+        "snapshotName": "snap",
+    }
+
+
+@pytest.mark.anyio
+async def test_async_sandbox_runtime_apis_use_expected_wire_keys():
+    transport = AsyncRecordingTransport()
+
+    processes = AsyncSandboxProcessesApi(transport)
+    process_input = SandboxExecParams(
+        command="echo hi",
+        timeout_ms=500,
+        timeout_sec=7,
+        use_shell=True,
+    )
+
+    await processes.exec(process_input)
+    handle = await processes.start(process_input)
+    await handle.wait(timeout_ms=250, timeout_sec=3)
+    await processes.list(
+        status=["running", "exited"],
+        limit=10,
+        cursor="cursor-1",
+        created_after=100,
+        created_before=200,
+    )
+
+    terminal = AsyncSandboxTerminalApi(transport, lambda: None)
+    terminal_handle = await terminal.create(
+        SandboxTerminalCreateParams(
+            command="bash",
+            use_shell=False,
+            rows=24,
+            cols=80,
+            timeout_ms=1500,
+        )
+    )
+    await terminal.get("pty_1", include_output=True)
+    await terminal_handle.wait(timeout_ms=800, include_output=True)
+
+    files = AsyncSandboxFilesApi(transport, lambda: None)
+    await files.get_watch("watch_1", include_events=True)
+    await files.upload_url("/tmp/file.txt", expires_in_seconds=60, one_time=True)
+    await files.download_url("/tmp/file.txt", expires_in_seconds=30, one_time=False)
+    await files.move(
+        source="/tmp/source.txt",
+        destination="/tmp/destination.txt",
+        overwrite=True,
+    )
+
+    assert transport.calls[0]["json_body"] == {
+        "command": "echo hi",
+        "timeoutMs": 500,
+        "timeout_sec": 7,
+        "useShell": True,
+    }
+    assert transport.calls[1]["json_body"] == {
+        "command": "echo hi",
+        "timeoutMs": 500,
+        "timeout_sec": 7,
+        "useShell": True,
+    }
+    assert transport.calls[2]["json_body"] == {
+        "timeoutMs": 250,
+        "timeout_sec": 3,
+    }
+    assert transport.calls[3]["params"] == {
+        "status": "running,exited",
+        "limit": 10,
+        "cursor": "cursor-1",
+        "created_after": 100,
+        "created_before": 200,
+    }
+    assert transport.calls[4]["json_body"] == {
+        "command": "bash",
+        "useShell": False,
+        "rows": 24,
+        "cols": 80,
+        "timeoutMs": 1500,
+    }
+    assert transport.calls[5]["params"] == {"includeOutput": True}
+    assert transport.calls[6]["json_body"] == {
+        "timeoutMs": 800,
+        "includeOutput": True,
+    }
+    assert transport.calls[7]["params"] == {"includeEvents": True}
+    assert transport.calls[8]["json_body"] == {
+        "path": "/tmp/file.txt",
+        "expiresInSeconds": 60,
+        "oneTime": True,
+    }
+    assert transport.calls[9]["json_body"] == {
+        "path": "/tmp/file.txt",
+        "expiresInSeconds": 30,
+        "oneTime": False,
+    }
+    assert transport.calls[10]["json_body"] == {
+        "from": "/tmp/source.txt",
+        "to": "/tmp/destination.txt",
+        "overwrite": True,
+    }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds an `overwrite` option to `rename`/`move`, which can change file-destruction semantics if callers enable it or if server-side behavior differs. Changes are localized but affect core filesystem mutation APIs and their wire payloads.
> 
> **Overview**
> **Adds overwrite support for file moves/renames in the sandbox files API.** `SandboxFilesApi.rename()` (sync + async) now accepts `overwrite` and sends it in the `/sandbox/files/move` request payload, with `move()` passing the flag through.
> 
> E2E tests are extended to verify `move(overwrite=True)` correctly replaces a symlink destination without modifying the symlink’s former target and that the source path is removed. A new `tests/test_sandbox_wire_contract.py` is added to lock down SDK request serialization and runtime API wire keys (including `from`/`to` + `overwrite` for moves), and the package version is bumped to `0.86.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13685c126b95b379f438af243dfb152968754f34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->