### PR TITLE
add gemini-3-flash-preview to gemini computer use

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -70,7 +70,10 @@ ClaudeComputerUseLlm = Literal[
     "claude-3-7-sonnet-20250219",
 ]
 CuaLlm = Literal["computer-use-preview", "gpt-5.4", "gpt-5.4-mini"]
-GeminiComputerUseLlm = Literal["gemini-2.5-computer-use-preview-10-2025",]
+GeminiComputerUseLlm = Literal[
+    "gemini-3-flash-preview",
+    "gemini-2.5-computer-use-preview-10-2025",
+]
 SessionRegion = Literal[
     "us-central",
     "asia-south",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.89.2"
+version = "0.89.3"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only expands a `Literal` model enum and bumps the package version, with no runtime logic changes beyond allowing a new string value.
> 
> **Overview**
> Adds `gemini-3-flash-preview` as an allowed value for `GeminiComputerUseLlm` in `hyperbrowser/models/consts.py`, enabling the new Gemini computer-use model identifier.
> 
> Bumps the SDK version in `pyproject.toml` from `0.89.2` to `0.89.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdf09044cca9a6fa220117b15d0794bfb239dd0f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->