### PR TITLE
fix web types

### DIFF
--- a/hyperbrowser/models/crawl.py
+++ b/hyperbrowser/models/crawl.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional, Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from hyperbrowser.models.scrape import ScrapeOptions
@@ -64,7 +64,7 @@ class CrawledPage(BaseModel):
     Data from a crawled page.
     """
 
-    metadata: Optional[dict[str, Union[str, list[str]]]] = None
+    metadata: Optional[dict[str, Any]] = None
     html: Optional[str] = None
     markdown: Optional[str] = None
     links: Optional[List[str]] = None

--- a/hyperbrowser/models/scrape.py
+++ b/hyperbrowser/models/scrape.py
@@ -1,4 +1,4 @@
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union, Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from hyperbrowser.models.consts import (
@@ -117,7 +117,7 @@ class ScrapeJobData(BaseModel):
     Data from a scraped site.
     """
 
-    metadata: Optional[dict[str, Union[str, list[str]]]] = None
+    metadata: Optional[dict[str, Any]] = None
     html: Optional[str] = None
     markdown: Optional[str] = None
     links: Optional[List[str]] = None
@@ -177,7 +177,7 @@ class ScrapedPage(BaseModel):
     url: str
     status: ScrapePageStatus
     error: Optional[str] = None
-    metadata: Optional[dict[str, Union[str, list[str]]]] = None
+    metadata: Optional[dict[str, Any]] = None
     html: Optional[str] = None
     markdown: Optional[str] = None
     links: Optional[List[str]] = None

--- a/hyperbrowser/models/web/common.py
+++ b/hyperbrowser/models/web/common.py
@@ -71,7 +71,7 @@ class PageData(BaseModel):
     url: str
     status: PageStatus
     error: Optional[str] = None
-    metadata: Optional[dict[str, Union[str, list[str]]]] = None
+    metadata: Optional[dict[str, Any]] = None
     markdown: Optional[str] = None
     html: Optional[str] = None
     links: Optional[list[str]] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.89.3"
+version = "0.90.0"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Pydantic model type annotations for `metadata` fields plus a package version bump, with no behavioral logic changes.
> 
> **Overview**
> Broadens the `metadata` field type across crawl/scrape/fetch response models from a restricted `str | list[str]` union to `Any`, aligning SDK types with more flexible API payloads.
> 
> Bumps the package version to `0.90.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2125f11206bd706b158229c1a933af15bb9ebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->