### PR TITLE
Update sdk run as sandbox

### DIFF
--- a/hyperbrowser/client/managers/async_manager/sandbox.py
+++ b/hyperbrowser/client/managers/async_manager/sandbox.py
@@ -217,16 +217,24 @@ class SandboxHandle:
             )
         return _copy_model(self._runtime_session)
 
-    async def exec(self, input: Union[str, SandboxExecParams]):
-        if isinstance(input, str):
-            params = SandboxExecParams(command=input)
-        else:
-            if not isinstance(input, SandboxExecParams):
-                raise TypeError(
-                    "input must be a command string or SandboxExecParams instance"
-                )
-            params = input
-        return await self.processes.exec(params)
+    async def exec(
+        self,
+        input: Union[str, SandboxExecParams],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout_ms: Optional[int] = None,
+        timeout_sec: Optional[int] = None,
+        run_as: Optional[str] = None,
+    ):
+        return await self.processes.exec(
+            input,
+            cwd=cwd,
+            env=env,
+            timeout_ms=timeout_ms,
+            timeout_sec=timeout_sec,
+            run_as=run_as,
+        )
 
     async def get_process(self, process_id: str) -> SandboxProcessHandle:
         return await self.processes.get(process_id)

--- a/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_files.py
+++ b/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_files.py
@@ -5,7 +5,7 @@ import io
 import json
 import socket
 from datetime import datetime
-from typing import AsyncIterator, Callable, List, Optional, Union
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional, Union
 from urllib.parse import urlencode
 
 from websockets.asyncio.client import connect as async_ws_connect
@@ -249,10 +249,21 @@ class SandboxFilesApi:
         transport: RuntimeTransport,
         get_connection_info,
         runtime_proxy_override: Optional[str] = None,
+        default_run_as: Optional[str] = None,
     ):
         self._transport = transport
         self._get_connection_info = get_connection_info
         self._runtime_proxy_override = runtime_proxy_override
+        self._default_run_as = default_run_as.strip() if default_run_as else None
+
+    def with_run_as(self, run_as: Optional[str]):
+        normalized = run_as.strip() if run_as else None
+        return SandboxFilesApi(
+            self._transport,
+            self._get_connection_info,
+            self._runtime_proxy_override,
+            default_run_as=normalized,
+        )
 
     async def list(
         self,
@@ -266,17 +277,19 @@ class SandboxFilesApi:
 
         payload = await self._transport.request_json(
             "/sandbox/files",
-            params={
-                "path": path,
-                "depth": depth,
-            },
+            params=self._with_run_as_params(
+                {
+                    "path": path,
+                    "depth": depth,
+                }
+            ),
         )
         return [_normalize_file_info(entry) for entry in payload.get("entries", [])]
 
     async def get_info(self, path: str) -> SandboxFileInfo:
         payload = await self._transport.request_json(
             "/sandbox/files/stat",
-            params={"path": path},
+            params=self._with_run_as_params({"path": path}),
         )
         return _normalize_file_info(payload["file"])
 
@@ -357,10 +370,12 @@ class SandboxFilesApi:
             payload = await self._transport.request_json(
                 "/sandbox/files/write",
                 method="POST",
-                json_body={
-                    "path": path_or_files,
-                    **_encode_write_data(data),
-                },
+                json_body=self._with_run_as_body(
+                    {
+                        "path": path_or_files,
+                        **_encode_write_data(data),
+                    }
+                ),
                 headers={"content-type": "application/json"},
             )
             return _normalize_write_info(payload["files"][0])
@@ -377,7 +392,7 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/write",
             method="POST",
-            json_body={"files": encoded_files},
+            json_body=self._with_run_as_body({"files": encoded_files}),
             headers={"content-type": "application/json"},
         )
         return [_normalize_write_info(entry) for entry in payload.get("files", [])]
@@ -419,7 +434,7 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/upload",
             method="PUT",
-            params={"path": path},
+            params=self._with_run_as_params({"path": path}),
             content=body,
         )
         return SandboxFileTransferResult(**payload)
@@ -427,7 +442,7 @@ class SandboxFilesApi:
     async def download(self, path: str) -> bytes:
         return await self._transport.request_bytes(
             "/sandbox/files/download",
-            params={"path": path},
+            params=self._with_run_as_params({"path": path}),
         )
 
     async def make_dir(
@@ -440,11 +455,13 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/mkdir",
             method="POST",
-            json_body={
-                "path": path,
-                "parents": parents,
-                "mode": mode,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "parents": parents,
+                    "mode": mode,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return bool(payload.get("created"))
@@ -475,7 +492,7 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/move",
             method="POST",
-            json_body=payload,
+            json_body=self._with_run_as_body(payload),
             headers={"content-type": "application/json"},
         )
         return _normalize_file_info(payload["entry"])
@@ -493,10 +510,12 @@ class SandboxFilesApi:
         await self._transport.request_json(
             "/sandbox/files/delete",
             method="POST",
-            json_body=SandboxFileDeleteParams(
-                path=path,
-                recursive=recursive,
-            ).model_dump(exclude_none=True),
+            json_body=self._with_run_as_body(
+                SandboxFileDeleteParams(
+                    path=path,
+                    recursive=recursive,
+                ).model_dump(exclude_none=True)
+            ),
             headers={"content-type": "application/json"},
         )
 
@@ -527,12 +546,14 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/copy",
             method="POST",
-            json_body={
-                "from": normalized.source,
-                "to": normalized.destination,
-                "recursive": normalized.recursive,
-                "overwrite": normalized.overwrite,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "from": normalized.source,
+                    "to": normalized.destination,
+                    "recursive": normalized.recursive,
+                    "overwrite": normalized.overwrite,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return _normalize_file_info(payload["entry"])
@@ -558,7 +579,7 @@ class SandboxFilesApi:
         await self._transport.request_json(
             "/sandbox/files/chmod",
             method="POST",
-            json_body=normalized.model_dump(exclude_none=True),
+            json_body=self._with_run_as_body(normalized.model_dump(exclude_none=True)),
             headers={"content-type": "application/json"},
         )
 
@@ -585,7 +606,7 @@ class SandboxFilesApi:
         await self._transport.request_json(
             "/sandbox/files/chown",
             method="POST",
-            json_body=normalized.model_dump(exclude_none=True),
+            json_body=self._with_run_as_body(normalized.model_dump(exclude_none=True)),
             headers={"content-type": "application/json"},
         )
 
@@ -593,10 +614,12 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/watch",
             method="POST",
-            json_body={
-                "path": path,
-                "recursive": recursive,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "recursive": recursive,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxFileWatchHandle(
@@ -646,11 +669,13 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/presign-upload",
             method="POST",
-            json_body=SandboxPresignFileParams(
-                path=path,
-                expires_in_seconds=expires_in_seconds,
-                one_time=one_time,
-            ).model_dump(exclude_none=True, by_alias=True),
+            json_body=self._with_run_as_body(
+                SandboxPresignFileParams(
+                    path=path,
+                    expires_in_seconds=expires_in_seconds,
+                    one_time=one_time,
+                ).model_dump(exclude_none=True, by_alias=True)
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxPresignedUrl(**payload)
@@ -665,11 +690,13 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/presign-download",
             method="POST",
-            json_body=SandboxPresignFileParams(
-                path=path,
-                expires_in_seconds=expires_in_seconds,
-                one_time=one_time,
-            ).model_dump(exclude_none=True, by_alias=True),
+            json_body=self._with_run_as_body(
+                SandboxPresignFileParams(
+                    path=path,
+                    expires_in_seconds=expires_in_seconds,
+                    one_time=one_time,
+                ).model_dump(exclude_none=True, by_alias=True)
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxPresignedUrl(**payload)
@@ -685,12 +712,14 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/read",
             method="POST",
-            json_body={
-                "path": path,
-                "offset": offset,
-                "length": length,
-                "encoding": encoding,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "offset": offset,
+                    "length": length,
+                    "encoding": encoding,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxFileReadResult(**payload)
@@ -707,13 +736,31 @@ class SandboxFilesApi:
         payload = await self._transport.request_json(
             "/sandbox/files/write",
             method="POST",
-            json_body={
-                "path": path,
-                "data": data,
-                "append": append,
-                "mode": mode,
-                "encoding": encoding,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "data": data,
+                    "append": append,
+                    "mode": mode,
+                    "encoding": encoding,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return _normalize_write_info(payload["files"][0])
+
+    def _with_run_as_params(
+        self, params: Dict[str, Union[str, int, bool, None]]
+    ) -> Dict[str, Union[str, int, bool, None]]:
+        if not self._default_run_as:
+            return params
+        enriched = dict(params)
+        enriched["runAs"] = self._default_run_as
+        return enriched
+
+    def _with_run_as_body(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._default_run_as:
+            return body
+        enriched = dict(body)
+        enriched["runAs"] = self._default_run_as
+        return enriched

--- a/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_processes.py
+++ b/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_processes.py
@@ -1,5 +1,4 @@
 import base64
-import re
 from typing import AsyncIterator, Dict, Optional, Union
 
 from .....models.sandbox import (
@@ -11,67 +10,10 @@ from .....models.sandbox import (
     SandboxProcessStdinParams,
     SandboxProcessSummary,
 )
+from ...sandboxes.shared import _normalize_exec_params
 from .sandbox_transport import RuntimeTransport
 
 DEFAULT_PROCESS_KILL_WAIT_SECONDS = 5.0
-SHELL_SAFE_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9_@%+=:,./-]+$")
-
-
-def _quote_shell_token(token: str) -> str:
-    if token == "":
-        return "''"
-    if SHELL_SAFE_TOKEN_PATTERN.fullmatch(token):
-        return token
-    return "'" + token.replace("'", "'\"'\"'") + "'"
-
-
-def _normalize_legacy_process_fields(params: SandboxExecParams) -> SandboxExecParams:
-    updates = {}
-
-    if params.args:
-        updates["command"] = " ".join(
-            _quote_shell_token(token) for token in [params.command, *params.args]
-        )
-
-    if params.args is not None:
-        updates["args"] = None
-
-    if params.use_shell is not None:
-        updates["use_shell"] = None
-
-    return params.model_copy(update=updates) if updates else params
-
-
-def _normalize_exec_params(
-    input: Union[str, SandboxExecParams],
-    *,
-    cwd: Optional[str] = None,
-    env: Optional[Dict[str, str]] = None,
-    timeout_ms: Optional[int] = None,
-    timeout_sec: Optional[int] = None,
-    run_as: Optional[str] = None,
-) -> SandboxExecParams:
-    if isinstance(input, str):
-        params = SandboxExecParams(command=input)
-    elif isinstance(input, SandboxExecParams):
-        params = input
-    else:
-        raise TypeError("input must be a command string or SandboxExecParams instance")
-
-    updates = {}
-    if cwd is not None:
-        updates["cwd"] = cwd
-    if env is not None:
-        updates["env"] = env
-    if timeout_ms is not None:
-        updates["timeout_ms"] = timeout_ms
-    if timeout_sec is not None:
-        updates["timeout_sec"] = timeout_sec
-    if run_as is not None:
-        updates["run_as"] = run_as
-
-    normalized = params.model_copy(update=updates) if updates else params
-    return _normalize_legacy_process_fields(normalized)
 
 
 class SandboxProcessHandle:

--- a/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_processes.py
+++ b/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_processes.py
@@ -15,6 +15,37 @@ from .sandbox_transport import RuntimeTransport
 DEFAULT_PROCESS_KILL_WAIT_SECONDS = 5.0
 
 
+def _normalize_exec_params(
+    input: Union[str, SandboxExecParams],
+    *,
+    cwd: Optional[str] = None,
+    env: Optional[Dict[str, str]] = None,
+    timeout_ms: Optional[int] = None,
+    timeout_sec: Optional[int] = None,
+    run_as: Optional[str] = None,
+) -> SandboxExecParams:
+    if isinstance(input, str):
+        params = SandboxExecParams(command=input)
+    elif isinstance(input, SandboxExecParams):
+        params = input
+    else:
+        raise TypeError("input must be a command string or SandboxExecParams instance")
+
+    updates = {}
+    if cwd is not None:
+        updates["cwd"] = cwd
+    if env is not None:
+        updates["env"] = env
+    if timeout_ms is not None:
+        updates["timeout_ms"] = timeout_ms
+    if timeout_sec is not None:
+        updates["timeout_sec"] = timeout_sec
+    if run_as is not None:
+        updates["run_as"] = run_as
+
+    return params.model_copy(update=updates) if updates else params
+
+
 class SandboxProcessHandle:
     def __init__(self, transport: RuntimeTransport, summary: SandboxProcessSummary):
         self._transport = transport
@@ -147,24 +178,54 @@ class SandboxProcessesApi:
     def __init__(self, transport: RuntimeTransport):
         self._transport = transport
 
-    async def exec(self, input: SandboxExecParams) -> SandboxProcessResult:
-        if not isinstance(input, SandboxExecParams):
-            raise TypeError("input must be a SandboxExecParams instance")
+    async def exec(
+        self,
+        input: Union[str, SandboxExecParams],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout_ms: Optional[int] = None,
+        timeout_sec: Optional[int] = None,
+        run_as: Optional[str] = None,
+    ) -> SandboxProcessResult:
+        params = _normalize_exec_params(
+            input,
+            cwd=cwd,
+            env=env,
+            timeout_ms=timeout_ms,
+            timeout_sec=timeout_sec,
+            run_as=run_as,
+        )
         payload = await self._transport.request_json(
             "/sandbox/exec",
             method="POST",
-            json_body=input.model_dump(exclude_none=True, by_alias=True),
+            json_body=params.model_dump(exclude_none=True, by_alias=True),
             headers={"content-type": "application/json"},
         )
         return SandboxProcessResult(**payload["result"])
 
-    async def start(self, input: SandboxExecParams) -> SandboxProcessHandle:
-        if not isinstance(input, SandboxExecParams):
-            raise TypeError("input must be a SandboxExecParams instance")
+    async def start(
+        self,
+        input: Union[str, SandboxExecParams],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout_ms: Optional[int] = None,
+        timeout_sec: Optional[int] = None,
+        run_as: Optional[str] = None,
+    ) -> SandboxProcessHandle:
+        params = _normalize_exec_params(
+            input,
+            cwd=cwd,
+            env=env,
+            timeout_ms=timeout_ms,
+            timeout_sec=timeout_sec,
+            run_as=run_as,
+        )
         payload = await self._transport.request_json(
             "/sandbox/processes",
             method="POST",
-            json_body=input.model_dump(exclude_none=True, by_alias=True),
+            json_body=params.model_dump(exclude_none=True, by_alias=True),
             headers={"content-type": "application/json"},
         )
         return SandboxProcessHandle(

--- a/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_processes.py
+++ b/hyperbrowser/client/managers/async_manager/sandboxes/sandbox_processes.py
@@ -1,4 +1,5 @@
 import base64
+import re
 from typing import AsyncIterator, Dict, Optional, Union
 
 from .....models.sandbox import (
@@ -13,6 +14,32 @@ from .....models.sandbox import (
 from .sandbox_transport import RuntimeTransport
 
 DEFAULT_PROCESS_KILL_WAIT_SECONDS = 5.0
+SHELL_SAFE_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9_@%+=:,./-]+$")
+
+
+def _quote_shell_token(token: str) -> str:
+    if token == "":
+        return "''"
+    if SHELL_SAFE_TOKEN_PATTERN.fullmatch(token):
+        return token
+    return "'" + token.replace("'", "'\"'\"'") + "'"
+
+
+def _normalize_legacy_process_fields(params: SandboxExecParams) -> SandboxExecParams:
+    updates = {}
+
+    if params.args:
+        updates["command"] = " ".join(
+            _quote_shell_token(token) for token in [params.command, *params.args]
+        )
+
+    if params.args is not None:
+        updates["args"] = None
+
+    if params.use_shell is not None:
+        updates["use_shell"] = None
+
+    return params.model_copy(update=updates) if updates else params
 
 
 def _normalize_exec_params(
@@ -43,7 +70,8 @@ def _normalize_exec_params(
     if run_as is not None:
         updates["run_as"] = run_as
 
-    return params.model_copy(update=updates) if updates else params
+    normalized = params.model_copy(update=updates) if updates else params
+    return _normalize_legacy_process_fields(normalized)
 
 
 class SandboxProcessHandle:

--- a/hyperbrowser/client/managers/sandboxes/shared.py
+++ b/hyperbrowser/client/managers/sandboxes/shared.py
@@ -1,11 +1,13 @@
 import base64
 import posixpath
+import re
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Optional, Union
 from urllib.parse import urlencode, urlsplit, urlunsplit
 
 from ....exceptions import HyperbrowserError
 from ....models.sandbox import (
+    SandboxExecParams,
     SandboxFileInfo,
     SandboxFileWriteEntry,
     SandboxFileWriteInfo,
@@ -18,10 +20,68 @@ from ....sandbox_common import (
 )
 
 DEFAULT_WATCH_TIMEOUT_MS = 60_000
+SHELL_SAFE_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9_@%+=:,./-]+$")
 
 
 def _copy_model(model):
     return model.model_copy(deep=True)
+
+
+def _quote_shell_token(token: str) -> str:
+    if token == "":
+        return "''"
+    if SHELL_SAFE_TOKEN_PATTERN.fullmatch(token):
+        return token
+    return "'" + token.replace("'", "'\"'\"'") + "'"
+
+
+def _normalize_legacy_process_fields(params: SandboxExecParams) -> SandboxExecParams:
+    updates = {}
+
+    if params.args:
+        updates["command"] = " ".join(
+            _quote_shell_token(token) for token in [params.command, *params.args]
+        )
+
+    if params.args is not None:
+        updates["args"] = None
+
+    if params.use_shell is not None:
+        updates["use_shell"] = None
+
+    return params.model_copy(update=updates) if updates else params
+
+
+def _normalize_exec_params(
+    input: Union[str, SandboxExecParams],
+    *,
+    cwd: Optional[str] = None,
+    env: Optional[Dict[str, str]] = None,
+    timeout_ms: Optional[int] = None,
+    timeout_sec: Optional[int] = None,
+    run_as: Optional[str] = None,
+) -> SandboxExecParams:
+    if isinstance(input, str):
+        params = SandboxExecParams(command=input)
+    elif isinstance(input, SandboxExecParams):
+        params = input
+    else:
+        raise TypeError("input must be a command string or SandboxExecParams instance")
+
+    updates = {}
+    if cwd is not None:
+        updates["cwd"] = cwd
+    if env is not None:
+        updates["env"] = env
+    if timeout_ms is not None:
+        updates["timeout_ms"] = timeout_ms
+    if timeout_sec is not None:
+        updates["timeout_sec"] = timeout_sec
+    if run_as is not None:
+        updates["run_as"] = run_as
+
+    normalized = params.model_copy(update=updates) if updates else params
+    return _normalize_legacy_process_fields(normalized)
 
 
 def _build_sandbox_exposed_url(runtime, port: int) -> str:

--- a/hyperbrowser/client/managers/sync_manager/sandbox.py
+++ b/hyperbrowser/client/managers/sync_manager/sandbox.py
@@ -217,16 +217,24 @@ class SandboxHandle:
             )
         return _copy_model(self._runtime_session)
 
-    def exec(self, input: Union[str, SandboxExecParams]):
-        if isinstance(input, str):
-            params = SandboxExecParams(command=input)
-        else:
-            if not isinstance(input, SandboxExecParams):
-                raise TypeError(
-                    "input must be a command string or SandboxExecParams instance"
-                )
-            params = input
-        return self.processes.exec(params)
+    def exec(
+        self,
+        input: Union[str, SandboxExecParams],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout_ms: Optional[int] = None,
+        timeout_sec: Optional[int] = None,
+        run_as: Optional[str] = None,
+    ):
+        return self.processes.exec(
+            input,
+            cwd=cwd,
+            env=env,
+            timeout_ms=timeout_ms,
+            timeout_sec=timeout_sec,
+            run_as=run_as,
+        )
 
     def get_process(self, process_id: str) -> SandboxProcessHandle:
         return self.processes.get(process_id)

--- a/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_files.py
+++ b/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_files.py
@@ -4,7 +4,7 @@ import json
 import socket
 import threading
 from datetime import datetime
-from typing import Callable, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 from urllib.parse import urlencode
 
 from websockets.exceptions import ConnectionClosed
@@ -238,10 +238,21 @@ class SandboxFilesApi:
         transport: RuntimeTransport,
         get_connection_info,
         runtime_proxy_override: Optional[str] = None,
+        default_run_as: Optional[str] = None,
     ):
         self._transport = transport
         self._get_connection_info = get_connection_info
         self._runtime_proxy_override = runtime_proxy_override
+        self._default_run_as = default_run_as.strip() if default_run_as else None
+
+    def with_run_as(self, run_as: Optional[str]):
+        normalized = run_as.strip() if run_as else None
+        return SandboxFilesApi(
+            self._transport,
+            self._get_connection_info,
+            self._runtime_proxy_override,
+            default_run_as=normalized,
+        )
 
     def exists(self, path: str) -> bool:
         try:
@@ -260,7 +271,7 @@ class SandboxFilesApi:
     def get_info(self, path: str) -> SandboxFileInfo:
         payload = self._transport.request_json(
             "/sandbox/files/stat",
-            params={"path": path},
+            params=self._with_run_as_params({"path": path}),
         )
         return _normalize_file_info(payload["file"])
 
@@ -279,10 +290,12 @@ class SandboxFilesApi:
 
         payload = self._transport.request_json(
             "/sandbox/files",
-            params={
+            params=self._with_run_as_params(
+                {
                 "path": path,
                 "depth": depth,
-            },
+                }
+            ),
         )
         return [_normalize_file_info(entry) for entry in payload.get("entries", [])]
 
@@ -338,10 +351,12 @@ class SandboxFilesApi:
             payload = self._transport.request_json(
                 "/sandbox/files/write",
                 method="POST",
-                json_body={
-                    "path": path_or_files,
-                    **_encode_write_data(data),
-                },
+                json_body=self._with_run_as_body(
+                    {
+                        "path": path_or_files,
+                        **_encode_write_data(data),
+                    }
+                ),
                 headers={"content-type": "application/json"},
             )
             return _normalize_write_info(payload["files"][0])
@@ -358,7 +373,7 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/write",
             method="POST",
-            json_body={"files": encoded_files},
+            json_body=self._with_run_as_body({"files": encoded_files}),
             headers={"content-type": "application/json"},
         )
         return [_normalize_write_info(entry) for entry in payload.get("files", [])]
@@ -400,7 +415,7 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/upload",
             method="PUT",
-            params={"path": path},
+            params=self._with_run_as_params({"path": path}),
             content=body,
         )
         return SandboxFileTransferResult(**payload)
@@ -408,7 +423,7 @@ class SandboxFilesApi:
     def download(self, path: str) -> bytes:
         return self._transport.request_bytes(
             "/sandbox/files/download",
-            params={"path": path},
+            params=self._with_run_as_params({"path": path}),
         )
 
     def make_dir(
@@ -421,11 +436,13 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/mkdir",
             method="POST",
-            json_body={
-                "path": path,
-                "parents": parents,
-                "mode": mode,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "parents": parents,
+                    "mode": mode,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return bool(payload.get("created"))
@@ -456,7 +473,7 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/move",
             method="POST",
-            json_body=payload,
+            json_body=self._with_run_as_body(payload),
             headers={"content-type": "application/json"},
         )
         return _normalize_file_info(payload["entry"])
@@ -474,10 +491,12 @@ class SandboxFilesApi:
         self._transport.request_json(
             "/sandbox/files/delete",
             method="POST",
-            json_body=SandboxFileDeleteParams(
-                path=path,
-                recursive=recursive,
-            ).model_dump(exclude_none=True),
+            json_body=self._with_run_as_body(
+                SandboxFileDeleteParams(
+                    path=path,
+                    recursive=recursive,
+                ).model_dump(exclude_none=True)
+            ),
             headers={"content-type": "application/json"},
         )
 
@@ -508,12 +527,14 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/copy",
             method="POST",
-            json_body={
-                "from": normalized.source,
-                "to": normalized.destination,
-                "recursive": normalized.recursive,
-                "overwrite": normalized.overwrite,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "from": normalized.source,
+                    "to": normalized.destination,
+                    "recursive": normalized.recursive,
+                    "overwrite": normalized.overwrite,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return _normalize_file_info(payload["entry"])
@@ -539,7 +560,7 @@ class SandboxFilesApi:
         self._transport.request_json(
             "/sandbox/files/chmod",
             method="POST",
-            json_body=normalized.model_dump(exclude_none=True),
+            json_body=self._with_run_as_body(normalized.model_dump(exclude_none=True)),
             headers={"content-type": "application/json"},
         )
 
@@ -566,7 +587,7 @@ class SandboxFilesApi:
         self._transport.request_json(
             "/sandbox/files/chown",
             method="POST",
-            json_body=normalized.model_dump(exclude_none=True),
+            json_body=self._with_run_as_body(normalized.model_dump(exclude_none=True)),
             headers={"content-type": "application/json"},
         )
 
@@ -574,10 +595,12 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/watch",
             method="POST",
-            json_body={
-                "path": path,
-                "recursive": recursive,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "recursive": recursive,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxFileWatchHandle(
@@ -627,11 +650,13 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/presign-upload",
             method="POST",
-            json_body=SandboxPresignFileParams(
-                path=path,
-                expires_in_seconds=expires_in_seconds,
-                one_time=one_time,
-            ).model_dump(exclude_none=True, by_alias=True),
+            json_body=self._with_run_as_body(
+                SandboxPresignFileParams(
+                    path=path,
+                    expires_in_seconds=expires_in_seconds,
+                    one_time=one_time,
+                ).model_dump(exclude_none=True, by_alias=True)
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxPresignedUrl(**payload)
@@ -646,11 +671,13 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/presign-download",
             method="POST",
-            json_body=SandboxPresignFileParams(
-                path=path,
-                expires_in_seconds=expires_in_seconds,
-                one_time=one_time,
-            ).model_dump(exclude_none=True, by_alias=True),
+            json_body=self._with_run_as_body(
+                SandboxPresignFileParams(
+                    path=path,
+                    expires_in_seconds=expires_in_seconds,
+                    one_time=one_time,
+                ).model_dump(exclude_none=True, by_alias=True)
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxPresignedUrl(**payload)
@@ -666,12 +693,14 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/read",
             method="POST",
-            json_body={
-                "path": path,
-                "offset": offset,
-                "length": length,
-                "encoding": encoding,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "offset": offset,
+                    "length": length,
+                    "encoding": encoding,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return SandboxFileReadResult(**payload)
@@ -688,13 +717,31 @@ class SandboxFilesApi:
         payload = self._transport.request_json(
             "/sandbox/files/write",
             method="POST",
-            json_body={
-                "path": path,
-                "data": data,
-                "append": append,
-                "mode": mode,
-                "encoding": encoding,
-            },
+            json_body=self._with_run_as_body(
+                {
+                    "path": path,
+                    "data": data,
+                    "append": append,
+                    "mode": mode,
+                    "encoding": encoding,
+                }
+            ),
             headers={"content-type": "application/json"},
         )
         return _normalize_write_info(payload["files"][0])
+
+    def _with_run_as_params(
+        self, params: Dict[str, Union[str, int, bool, None]]
+    ) -> Dict[str, Union[str, int, bool, None]]:
+        if not self._default_run_as:
+            return params
+        enriched = dict(params)
+        enriched["runAs"] = self._default_run_as
+        return enriched
+
+    def _with_run_as_body(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        if not self._default_run_as:
+            return body
+        enriched = dict(body)
+        enriched["runAs"] = self._default_run_as
+        return enriched

--- a/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_processes.py
+++ b/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_processes.py
@@ -1,4 +1,5 @@
 import base64
+import re
 from typing import Dict, Optional, Union
 
 from .....models.sandbox import (
@@ -13,6 +14,32 @@ from .....models.sandbox import (
 from .sandbox_transport import RuntimeTransport
 
 DEFAULT_PROCESS_KILL_WAIT_SECONDS = 5.0
+SHELL_SAFE_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9_@%+=:,./-]+$")
+
+
+def _quote_shell_token(token: str) -> str:
+    if token == "":
+        return "''"
+    if SHELL_SAFE_TOKEN_PATTERN.fullmatch(token):
+        return token
+    return "'" + token.replace("'", "'\"'\"'") + "'"
+
+
+def _normalize_legacy_process_fields(params: SandboxExecParams) -> SandboxExecParams:
+    updates = {}
+
+    if params.args:
+        updates["command"] = " ".join(
+            _quote_shell_token(token) for token in [params.command, *params.args]
+        )
+
+    if params.args is not None:
+        updates["args"] = None
+
+    if params.use_shell is not None:
+        updates["use_shell"] = None
+
+    return params.model_copy(update=updates) if updates else params
 
 
 def _normalize_exec_params(
@@ -43,7 +70,8 @@ def _normalize_exec_params(
     if run_as is not None:
         updates["run_as"] = run_as
 
-    return params.model_copy(update=updates) if updates else params
+    normalized = params.model_copy(update=updates) if updates else params
+    return _normalize_legacy_process_fields(normalized)
 
 
 class SandboxProcessHandle:

--- a/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_processes.py
+++ b/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_processes.py
@@ -1,5 +1,4 @@
 import base64
-import re
 from typing import Dict, Optional, Union
 
 from .....models.sandbox import (
@@ -11,67 +10,10 @@ from .....models.sandbox import (
     SandboxProcessStdinParams,
     SandboxProcessSummary,
 )
+from ...sandboxes.shared import _normalize_exec_params
 from .sandbox_transport import RuntimeTransport
 
 DEFAULT_PROCESS_KILL_WAIT_SECONDS = 5.0
-SHELL_SAFE_TOKEN_PATTERN = re.compile(r"^[A-Za-z0-9_@%+=:,./-]+$")
-
-
-def _quote_shell_token(token: str) -> str:
-    if token == "":
-        return "''"
-    if SHELL_SAFE_TOKEN_PATTERN.fullmatch(token):
-        return token
-    return "'" + token.replace("'", "'\"'\"'") + "'"
-
-
-def _normalize_legacy_process_fields(params: SandboxExecParams) -> SandboxExecParams:
-    updates = {}
-
-    if params.args:
-        updates["command"] = " ".join(
-            _quote_shell_token(token) for token in [params.command, *params.args]
-        )
-
-    if params.args is not None:
-        updates["args"] = None
-
-    if params.use_shell is not None:
-        updates["use_shell"] = None
-
-    return params.model_copy(update=updates) if updates else params
-
-
-def _normalize_exec_params(
-    input: Union[str, SandboxExecParams],
-    *,
-    cwd: Optional[str] = None,
-    env: Optional[Dict[str, str]] = None,
-    timeout_ms: Optional[int] = None,
-    timeout_sec: Optional[int] = None,
-    run_as: Optional[str] = None,
-) -> SandboxExecParams:
-    if isinstance(input, str):
-        params = SandboxExecParams(command=input)
-    elif isinstance(input, SandboxExecParams):
-        params = input
-    else:
-        raise TypeError("input must be a command string or SandboxExecParams instance")
-
-    updates = {}
-    if cwd is not None:
-        updates["cwd"] = cwd
-    if env is not None:
-        updates["env"] = env
-    if timeout_ms is not None:
-        updates["timeout_ms"] = timeout_ms
-    if timeout_sec is not None:
-        updates["timeout_sec"] = timeout_sec
-    if run_as is not None:
-        updates["run_as"] = run_as
-
-    normalized = params.model_copy(update=updates) if updates else params
-    return _normalize_legacy_process_fields(normalized)
 
 
 class SandboxProcessHandle:

--- a/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_processes.py
+++ b/hyperbrowser/client/managers/sync_manager/sandboxes/sandbox_processes.py
@@ -15,6 +15,37 @@ from .sandbox_transport import RuntimeTransport
 DEFAULT_PROCESS_KILL_WAIT_SECONDS = 5.0
 
 
+def _normalize_exec_params(
+    input: Union[str, SandboxExecParams],
+    *,
+    cwd: Optional[str] = None,
+    env: Optional[Dict[str, str]] = None,
+    timeout_ms: Optional[int] = None,
+    timeout_sec: Optional[int] = None,
+    run_as: Optional[str] = None,
+) -> SandboxExecParams:
+    if isinstance(input, str):
+        params = SandboxExecParams(command=input)
+    elif isinstance(input, SandboxExecParams):
+        params = input
+    else:
+        raise TypeError("input must be a command string or SandboxExecParams instance")
+
+    updates = {}
+    if cwd is not None:
+        updates["cwd"] = cwd
+    if env is not None:
+        updates["env"] = env
+    if timeout_ms is not None:
+        updates["timeout_ms"] = timeout_ms
+    if timeout_sec is not None:
+        updates["timeout_sec"] = timeout_sec
+    if run_as is not None:
+        updates["run_as"] = run_as
+
+    return params.model_copy(update=updates) if updates else params
+
+
 class SandboxProcessHandle:
     def __init__(self, transport: RuntimeTransport, summary: SandboxProcessSummary):
         self._transport = transport
@@ -143,24 +174,54 @@ class SandboxProcessesApi:
     def __init__(self, transport: RuntimeTransport):
         self._transport = transport
 
-    def exec(self, input: SandboxExecParams) -> SandboxProcessResult:
-        if not isinstance(input, SandboxExecParams):
-            raise TypeError("input must be a SandboxExecParams instance")
+    def exec(
+        self,
+        input: Union[str, SandboxExecParams],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout_ms: Optional[int] = None,
+        timeout_sec: Optional[int] = None,
+        run_as: Optional[str] = None,
+    ) -> SandboxProcessResult:
+        params = _normalize_exec_params(
+            input,
+            cwd=cwd,
+            env=env,
+            timeout_ms=timeout_ms,
+            timeout_sec=timeout_sec,
+            run_as=run_as,
+        )
         payload = self._transport.request_json(
             "/sandbox/exec",
             method="POST",
-            json_body=input.model_dump(exclude_none=True, by_alias=True),
+            json_body=params.model_dump(exclude_none=True, by_alias=True),
             headers={"content-type": "application/json"},
         )
         return SandboxProcessResult(**payload["result"])
 
-    def start(self, input: SandboxExecParams) -> SandboxProcessHandle:
-        if not isinstance(input, SandboxExecParams):
-            raise TypeError("input must be a SandboxExecParams instance")
+    def start(
+        self,
+        input: Union[str, SandboxExecParams],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        timeout_ms: Optional[int] = None,
+        timeout_sec: Optional[int] = None,
+        run_as: Optional[str] = None,
+    ) -> SandboxProcessHandle:
+        params = _normalize_exec_params(
+            input,
+            cwd=cwd,
+            env=env,
+            timeout_ms=timeout_ms,
+            timeout_sec=timeout_sec,
+            run_as=run_as,
+        )
         payload = self._transport.request_json(
             "/sandbox/processes",
             method="POST",
-            json_body=input.model_dump(exclude_none=True, by_alias=True),
+            json_body=params.model_dump(exclude_none=True, by_alias=True),
             headers={"content-type": "application/json"},
         )
         return SandboxProcessHandle(

--- a/hyperbrowser/models/sandbox.py
+++ b/hyperbrowser/models/sandbox.py
@@ -300,6 +300,7 @@ class SandboxExecParams(SandboxBaseModel):
     env: Optional[Dict[str, str]] = None
     timeout_ms: Optional[int] = Field(default=None, serialization_alias="timeoutMs")
     timeout_sec: Optional[int] = None
+    run_as: Optional[str] = Field(default=None, serialization_alias="runAs")
     use_shell: Optional[bool] = Field(default=None, serialization_alias="useShell")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.90.0"
+version = "0.90.1"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"

--- a/tests/sandbox/e2e/test_async_files.py
+++ b/tests/sandbox/e2e/test_async_files.py
@@ -18,8 +18,8 @@ def _read_stream_text(stream) -> str:
     return stream.read().decode("utf-8")
 
 
-def _bash_exec(command: str) -> SandboxExecParams:
-    return SandboxExecParams(command="bash", args=["-lc", command])
+def _bash_exec(command: str, run_as: str = "root") -> SandboxExecParams:
+    return SandboxExecParams(command="bash", args=["-lc", command], run_as=run_as)
 
 
 async def _await_future(future: asyncio.Future, timeout: float = 10.0):
@@ -65,16 +65,17 @@ async def test_async_sandbox_files_e2e():
             default_sandbox_params("py-async-files")
         )
         await wait_for_runtime_ready_async(sandbox)
+        files = sandbox.files.with_run_as("root")
 
-        assert await sandbox.files.exists(f"{base_dir}/missing.txt") is False
+        assert await files.exists(f"{base_dir}/missing.txt") is False
 
         path = f"{base_dir}/dirs/root"
-        assert await sandbox.files.make_dir(path) is True
-        assert await sandbox.files.make_dir(path) is False
+        assert await files.make_dir(path) is True
+        assert await files.make_dir(path) is False
 
         info_path = f"{base_dir}/info/hello.txt"
-        await sandbox.files.write_text(info_path, "hello from sdk files")
-        info = await sandbox.files.get_info(info_path)
+        await files.write_text(info_path, "hello from sdk files")
+        info = await files.get_info(info_path)
         assert info.name == "hello.txt"
         assert info.path == info_path
         assert info.type == "file"
@@ -86,18 +87,18 @@ async def test_async_sandbox_files_e2e():
         assert info.modified_time is not None
 
         list_dir = f"{base_dir}/list"
-        await sandbox.files.make_dir(f"{list_dir}/nested/inner", parents=True)
-        await sandbox.files.write_text(f"{list_dir}/root.txt", "root")
-        await sandbox.files.write_text(f"{list_dir}/nested/child.txt", "child")
-        await sandbox.files.write_text(
+        await files.make_dir(f"{list_dir}/nested/inner", parents=True)
+        await files.write_text(f"{list_dir}/root.txt", "root")
+        await files.write_text(f"{list_dir}/nested/child.txt", "child")
+        await files.write_text(
             f"{list_dir}/nested/inner/grandchild.txt", "grandchild"
         )
 
-        depth_one = await sandbox.files.list(list_dir, depth=1)
+        depth_one = await files.list(list_dir, depth=1)
         assert [entry.name for entry in depth_one] == ["nested", "root.txt"]
         assert [entry.type for entry in depth_one] == ["dir", "file"]
 
-        depth_two = await sandbox.files.list(list_dir, depth=2)
+        depth_two = await files.list(list_dir, depth=2)
         assert [entry.path for entry in depth_two] == [
             f"{list_dir}/nested",
             f"{list_dir}/nested/child.txt",
@@ -108,20 +109,20 @@ async def test_async_sandbox_files_e2e():
         symlink_dir = f"{base_dir}/list-symlink"
         target = f"{symlink_dir}/target.txt"
         link = f"{symlink_dir}/link.txt"
-        await sandbox.files.make_dir(symlink_dir)
-        await sandbox.files.write_text(target, "payload")
+        await files.make_dir(symlink_dir)
+        await files.write_text(target, "payload")
         result = await sandbox.exec(_bash_exec(f'ln -sfn "{target}" "{link}"'))
         assert result.exit_code == 0
         link_entry = next(
             entry
-            for entry in await sandbox.files.list(symlink_dir, depth=1)
+            for entry in await files.list(symlink_dir, depth=1)
             if entry.path == link
         )
         assert link_entry.symlink_target == target
 
         symlink_target = f"{base_dir}/symlink/target.txt"
         symlink_link = f"{base_dir}/symlink/link.txt"
-        await sandbox.files.write_text(symlink_target, "target")
+        await files.write_text(symlink_target, "target")
         result = await sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/symlink" && ln -sfn "{symlink_target}" "{symlink_link}"'
@@ -129,7 +130,7 @@ async def test_async_sandbox_files_e2e():
         )
         assert result.exit_code == 0
         assert (
-            await sandbox.files.get_info(symlink_link)
+            await files.get_info(symlink_link)
         ).symlink_target == symlink_target
 
         broken_target = f"{base_dir}/symlink-broken/missing-target.txt"
@@ -140,39 +141,39 @@ async def test_async_sandbox_files_e2e():
             )
         )
         assert result.exit_code == 0
-        assert await sandbox.files.exists(broken_link) is True
+        assert await files.exists(broken_link) is True
         assert (
-            await sandbox.files.get_info(broken_link)
+            await files.get_info(broken_link)
         ).symlink_target == broken_target
 
         read_path = f"{base_dir}/read/readme.txt"
-        await sandbox.files.write_text(read_path, "hello from sdk files")
-        assert await sandbox.files.read(read_path) == "hello from sdk files"
+        await files.write_text(read_path, "hello from sdk files")
+        assert await files.read(read_path) == "hello from sdk files"
         assert (
-            await sandbox.files.read(read_path, format="text", offset=6, length=4)
+            await files.read(read_path, format="text", offset=6, length=4)
             == "from"
         )
         assert (
-            await sandbox.files.read(read_path, format="bytes")
+            await files.read(read_path, format="bytes")
             == b"hello from sdk files"
         )
         assert (
-            await sandbox.files.read(read_path, format="blob")
+            await files.read(read_path, format="blob")
             == b"hello from sdk files"
         )
         assert (
-            _read_stream_text(await sandbox.files.read(read_path, format="stream"))
+            _read_stream_text(await files.read(read_path, format="stream"))
             == "hello from sdk files"
         )
 
-        single = await sandbox.files.write(
+        single = await files.write(
             f"{base_dir}/write/single.txt", "single file"
         )
         assert single.name == "single.txt"
         assert single.path == f"{base_dir}/write/single.txt"
-        assert await sandbox.files.read_text(single.path) == "single file"
+        assert await files.read_text(single.path) == "single file"
 
-        batch = await sandbox.files.write(
+        batch = await files.write(
             [
                 SandboxFileWriteEntry(
                     path=f"{base_dir}/write/batch-a.txt",
@@ -186,37 +187,37 @@ async def test_async_sandbox_files_e2e():
         )
         assert [entry.name for entry in batch] == ["batch-a.txt", "batch-b.bin"]
         assert (
-            await sandbox.files.read_text(f"{base_dir}/write/batch-a.txt") == "batch-a"
+            await files.read_text(f"{base_dir}/write/batch-a.txt") == "batch-a"
         )
-        assert await sandbox.files.read_bytes(f"{base_dir}/write/batch-b.bin") == bytes(
+        assert await files.read_bytes(f"{base_dir}/write/batch-b.bin") == bytes(
             [1, 2, 3, 4]
         )
 
         text_path = f"{base_dir}/write-options/text.txt"
-        await sandbox.files.write_text(text_path, "hello", mode="0640")
-        await sandbox.files.write_text(text_path, " world", append=True)
-        assert await sandbox.files.read_text(text_path) == "hello world"
-        assert (await sandbox.files.get_info(text_path)).mode == 0o640
+        await files.write_text(text_path, "hello", mode="0640")
+        await files.write_text(text_path, " world", append=True)
+        assert await files.read_text(text_path) == "hello world"
+        assert (await files.get_info(text_path)).mode == 0o640
 
         bytes_path = f"{base_dir}/write-options/bytes.bin"
-        await sandbox.files.write_bytes(bytes_path, bytes([1, 2]), mode="0600")
-        await sandbox.files.write_bytes(bytes_path, bytes([3]), append=True)
-        assert await sandbox.files.read_bytes(bytes_path) == bytes([1, 2, 3])
+        await files.write_bytes(bytes_path, bytes([1, 2]), mode="0600")
+        await files.write_bytes(bytes_path, bytes([3]), append=True)
+        assert await files.read_bytes(bytes_path) == bytes([1, 2, 3])
 
         transfer_path = f"{base_dir}/transfer/upload.txt"
-        uploaded = await sandbox.files.upload(transfer_path, "uploaded from sdk")
+        uploaded = await files.upload(transfer_path, "uploaded from sdk")
         assert uploaded.bytes_written > 0
-        assert (await sandbox.files.download(transfer_path)).decode(
+        assert (await files.download(transfer_path)).decode(
             "utf-8"
         ) == "uploaded from sdk"
 
         file_path = f"{base_dir}/rename/hello.txt"
         renamed_path = f"{base_dir}/rename/hello-renamed.txt"
-        await sandbox.files.write_text(file_path, "rename me")
-        renamed = await sandbox.files.rename(file_path, renamed_path)
+        await files.write_text(file_path, "rename me")
+        renamed = await files.rename(file_path, renamed_path)
         assert renamed.path == renamed_path
-        assert await sandbox.files.exists(file_path) is False
-        assert await sandbox.files.read_text(renamed_path) == "rename me"
+        assert await files.exists(file_path) is False
+        assert await files.read_text(renamed_path) == "rename me"
 
         link_path = f"{base_dir}/rename/hello-link.txt"
         copied_link_path = f"{base_dir}/rename/hello-link-copy.txt"
@@ -225,145 +226,145 @@ async def test_async_sandbox_files_e2e():
             _bash_exec(f'ln -sfn "{renamed_path}" "{link_path}"')
         )
         assert result.exit_code == 0
-        copied_link = await sandbox.files.copy(
+        copied_link = await files.copy(
             source=link_path, destination=copied_link_path
         )
         assert copied_link.path == copied_link_path
         assert (
-            await sandbox.files.get_info(copied_link_path)
+            await files.get_info(copied_link_path)
         ).symlink_target == renamed_path
-        renamed_link = await sandbox.files.rename(copied_link_path, renamed_link_path)
+        renamed_link = await files.rename(copied_link_path, renamed_link_path)
         assert renamed_link.path == renamed_link_path
         assert (
-            await sandbox.files.get_info(renamed_link_path)
+            await files.get_info(renamed_link_path)
         ).symlink_target == renamed_path
 
         target_dir = f"{base_dir}/rename-dir/target-dir"
         link_dir = f"{base_dir}/rename-dir/link-dir"
         renamed_link_dir = f"{base_dir}/rename-dir/link-dir-renamed"
-        await sandbox.files.make_dir(target_dir)
-        await sandbox.files.write_text(f"{target_dir}/child.txt", "child")
+        await files.make_dir(target_dir)
+        await files.write_text(f"{target_dir}/child.txt", "child")
         result = await sandbox.exec(_bash_exec(f'ln -sfn "{target_dir}" "{link_dir}"'))
         assert result.exit_code == 0
-        renamed = await sandbox.files.rename(link_dir, renamed_link_dir)
+        renamed = await files.rename(link_dir, renamed_link_dir)
         assert renamed.path == renamed_link_dir
         assert (
-            await sandbox.files.get_info(renamed_link_dir)
+            await files.get_info(renamed_link_dir)
         ).symlink_target == target_dir
         assert [
-            entry.path for entry in await sandbox.files.list(renamed_link_dir, depth=1)
+            entry.path for entry in await files.list(renamed_link_dir, depth=1)
         ] == [f"{target_dir}/child.txt"]
 
         source_dir = f"{base_dir}/copy-tree/source"
         nested_dir = f"{source_dir}/nested"
         nested_target = f"{nested_dir}/target.txt"
         destination_dir = f"{base_dir}/copy-tree/destination"
-        await sandbox.files.make_dir(nested_dir)
-        await sandbox.files.write_text(nested_target, "payload")
+        await files.make_dir(nested_dir)
+        await files.write_text(nested_target, "payload")
         result = await sandbox.exec(
             _bash_exec(f'cd "{nested_dir}" && ln -sfn "target.txt" "link.txt"')
         )
         assert result.exit_code == 0
-        await sandbox.files.copy(
+        await files.copy(
             source=source_dir, destination=destination_dir, recursive=True
         )
         copied_target = f"{destination_dir}/nested/target.txt"
         copied_link = f"{destination_dir}/nested/link.txt"
-        assert await sandbox.files.read_text(copied_target) == "payload"
+        assert await files.read_text(copied_target) == "payload"
         assert (
-            await sandbox.files.get_info(copied_link)
+            await files.get_info(copied_link)
         ).symlink_target == copied_target
 
         loop_dir = f"{base_dir}/loop-list"
         loop_nested_dir = f"{loop_dir}/nested"
-        await sandbox.files.make_dir(loop_nested_dir)
-        await sandbox.files.write_text(f"{loop_nested_dir}/child.txt", "payload")
+        await files.make_dir(loop_nested_dir)
+        await files.write_text(f"{loop_nested_dir}/child.txt", "payload")
         result = await sandbox.exec(
             _bash_exec(f'cd "{loop_nested_dir}" && ln -sfn .. loop')
         )
         assert result.exit_code == 0
-        loop_entries = await sandbox.files.list(loop_dir, depth=4)
+        loop_entries = await files.list(loop_dir, depth=4)
         loop_paths = [entry.path for entry in loop_entries]
         assert f"{loop_nested_dir}/loop" in loop_paths
         assert not any("/loop/" in path for path in loop_paths)
         assert (
-            await sandbox.files.get_info(f"{loop_nested_dir}/loop")
+            await files.get_info(f"{loop_nested_dir}/loop")
         ).symlink_target == loop_dir
 
         source_dir = f"{base_dir}/loop-copy/source"
         nested_dir = f"{source_dir}/nested"
-        await sandbox.files.make_dir(nested_dir)
-        await sandbox.files.write_text(f"{nested_dir}/child.txt", "payload")
+        await files.make_dir(nested_dir)
+        await files.write_text(f"{nested_dir}/child.txt", "payload")
         result = await sandbox.exec(_bash_exec(f'cd "{nested_dir}" && ln -sfn .. loop'))
         assert result.exit_code == 0
         destination_dir = f"{base_dir}/loop-copy/destination"
-        await sandbox.files.copy(
+        await files.copy(
             source=source_dir, destination=destination_dir, recursive=True
         )
         copied_loop = f"{destination_dir}/nested/loop"
         assert (
-            await sandbox.files.get_info(copied_loop)
+            await files.get_info(copied_loop)
         ).symlink_target == destination_dir
         assert not any(
             "/loop/" in entry.path
-            for entry in await sandbox.files.list(destination_dir, depth=4)
+            for entry in await files.list(destination_dir, depth=4)
         )
 
         source = f"{base_dir}/copy-overwrite/source.txt"
         existing_target = f"{base_dir}/copy-overwrite/existing-target.txt"
         destination_link = f"{base_dir}/copy-overwrite/destination-link.txt"
-        await sandbox.files.write_text(source, "source payload")
-        await sandbox.files.write_text(existing_target, "existing target")
+        await files.write_text(source, "source payload")
+        await files.write_text(existing_target, "existing target")
         result = await sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/copy-overwrite" && ln -sfn "{existing_target}" "{destination_link}"'
             )
         )
         assert result.exit_code == 0
-        await sandbox.files.copy(
+        await files.copy(
             source=source, destination=destination_link, overwrite=True
         )
-        assert await sandbox.files.read_text(destination_link) == "source payload"
-        assert await sandbox.files.read_text(existing_target) == "existing target"
-        assert (await sandbox.files.get_info(destination_link)).symlink_target is None
+        assert await files.read_text(destination_link) == "source payload"
+        assert await files.read_text(existing_target) == "existing target"
+        assert (await files.get_info(destination_link)).symlink_target is None
 
         move_source = f"{base_dir}/move-overwrite/source.txt"
         move_existing_target = f"{base_dir}/move-overwrite/existing-target.txt"
         move_destination_link = f"{base_dir}/move-overwrite/destination-link.txt"
-        await sandbox.files.write_text(move_source, "move source payload")
-        await sandbox.files.write_text(move_existing_target, "move existing target")
+        await files.write_text(move_source, "move source payload")
+        await files.write_text(move_existing_target, "move existing target")
         result = await sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/move-overwrite" && ln -sfn "{move_existing_target}" "{move_destination_link}"'
             )
         )
         assert result.exit_code == 0
-        await sandbox.files.move(
+        await files.move(
             source=move_source,
             destination=move_destination_link,
             overwrite=True,
         )
         assert (
-            await sandbox.files.read_text(move_destination_link)
+            await files.read_text(move_destination_link)
             == "move source payload"
         )
         assert (
-            await sandbox.files.read_text(move_existing_target)
+            await files.read_text(move_existing_target)
             == "move existing target"
         )
         assert (
-            await sandbox.files.get_info(move_destination_link)
+            await files.get_info(move_destination_link)
         ).symlink_target is None
-        assert await sandbox.files.exists(move_source) is False
+        assert await files.exists(move_source) is False
 
         chmod_path = f"{base_dir}/chmod/file.txt"
-        await sandbox.files.write_text(chmod_path, "chmod me")
-        await sandbox.files.chmod(path=chmod_path, mode="0640")
-        assert (await sandbox.files.get_info(chmod_path)).mode == 0o640
+        await files.write_text(chmod_path, "chmod me")
+        await files.chmod(path=chmod_path, mode="0640")
+        assert (await files.get_info(chmod_path)).mode == 0o640
         try:
             await expect_hyperbrowser_error_async(
                 "file chown",
-                lambda: sandbox.files.chown(path=chmod_path, uid=0, gid=0),
+                lambda: files.chown(path=chmod_path, uid=0, gid=0),
                 status_code=400,
                 service="runtime",
                 retryable=False,
@@ -372,75 +373,75 @@ async def test_async_sandbox_files_e2e():
         except AssertionError as error:
             if "expected HyperbrowserError, but call succeeded" not in str(error):
                 raise
-            assert (await sandbox.files.get_info(chmod_path)).name == "file.txt"
+            assert (await files.get_info(chmod_path)).name == "file.txt"
 
         remove_path = f"{base_dir}/remove/file.txt"
-        await sandbox.files.write_text(remove_path, "remove me")
-        await sandbox.files.remove(remove_path)
-        assert await sandbox.files.exists(remove_path) is False
-        await sandbox.files.remove(remove_path)
-        await sandbox.files.remove(f"{base_dir}/remove", recursive=True)
-        assert await sandbox.files.exists(f"{base_dir}/remove") is False
+        await files.write_text(remove_path, "remove me")
+        await files.remove(remove_path)
+        assert await files.exists(remove_path) is False
+        await files.remove(remove_path)
+        await files.remove(f"{base_dir}/remove", recursive=True)
+        assert await files.exists(f"{base_dir}/remove") is False
 
         target = f"{base_dir}/remove-link/target.txt"
         link = f"{base_dir}/remove-link/link.txt"
-        await sandbox.files.write_text(target, "keep me")
+        await files.write_text(target, "keep me")
         result = await sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/remove-link" && ln -sfn "{target}" "{link}"'
             )
         )
         assert result.exit_code == 0
-        await sandbox.files.remove(link)
-        assert await sandbox.files.exists(link) is False
-        assert await sandbox.files.read_text(target) == "keep me"
+        await files.remove(link)
+        assert await files.exists(link) is False
+        assert await files.read_text(target) == "keep me"
 
         target_dir = f"{base_dir}/remove-recursive/target-dir"
         target_file = f"{target_dir}/child.txt"
         link_dir = f"{base_dir}/remove-recursive/link-dir"
-        await sandbox.files.make_dir(target_dir)
-        await sandbox.files.write_text(target_file, "keep tree")
+        await files.make_dir(target_dir)
+        await files.write_text(target_file, "keep tree")
         result = await sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/remove-recursive" && ln -sfn "{target_dir}" "{link_dir}"'
             )
         )
         assert result.exit_code == 0
-        await sandbox.files.remove(link_dir, recursive=True)
-        assert await sandbox.files.exists(link_dir) is False
-        assert await sandbox.files.read_text(target_file) == "keep tree"
+        await files.remove(link_dir, recursive=True)
+        assert await files.exists(link_dir) is False
+        assert await files.read_text(target_file) == "keep tree"
 
         link = f"{base_dir}/escape/file-link"
         result = await sandbox.exec(
             _bash_exec(f'mkdir -p "{base_dir}/escape" && ln -sfn /etc/hosts "{link}"')
         )
         assert result.exit_code == 0
-        text = await sandbox.files.read_text(link)
+        text = await files.read_text(link)
         assert "localhost" in text
-        assert "localhost" in (await sandbox.files.download(link)).decode("utf-8")
+        assert "localhost" in (await files.download(link)).decode("utf-8")
 
         fixture = await _create_parent_symlink_escape_fixture(
             sandbox, base_dir, "parent-escape-read"
         )
         assert (
-            await sandbox.files.read_text(fixture["escaped_file"]) == "outside secret"
+            await files.read_text(fixture["escaped_file"]) == "outside secret"
         )
-        assert (await sandbox.files.download(fixture["escaped_file"])).decode(
+        assert (await files.download(fixture["escaped_file"])).decode(
             "utf-8"
         ) == "outside secret"
         assert [
             entry.path
-            for entry in await sandbox.files.list(fixture["link_dir"], depth=1)
+            for entry in await files.list(fixture["link_dir"], depth=1)
         ] == [f"{fixture['outside_dir']}/secret.txt"]
         seen = asyncio.get_running_loop().create_future()
 
         async def on_parent_event(event):
-            if event.type == "write" and event.name == "fresh.txt" and not seen.done():
+            if event.type in {"create", "write"} and event.name == "fresh.txt" and not seen.done():
                 seen.set_result(event.name)
 
-        handle = await sandbox.files.watch_dir(fixture["link_dir"], on_parent_event)
+        handle = await files.watch_dir(fixture["link_dir"], on_parent_event)
         try:
-            await sandbox.files.write_text(
+            await files.write_text(
                 f"{fixture['outside_dir']}/fresh.txt", "watch parent link"
             )
             assert await _await_future(seen) == "fresh.txt"
@@ -450,24 +451,24 @@ async def test_async_sandbox_files_e2e():
         fixture = await _create_parent_symlink_escape_fixture(
             sandbox, base_dir, "parent-escape-mutate"
         )
-        info = await sandbox.files.get_info(fixture["escaped_file"])
+        info = await files.get_info(fixture["escaped_file"])
         assert info.type == "file"
         assert info.size == len("outside secret")
-        copied = await sandbox.files.copy(
+        copied = await files.copy(
             source=fixture["escaped_file"],
             destination=f"{base_dir}/parent-escape-mutate/copied.txt",
         )
         assert copied.path == f"{base_dir}/parent-escape-mutate/copied.txt"
-        assert await sandbox.files.read_text(copied.path) == "outside secret"
-        renamed = await sandbox.files.rename(
+        assert await files.read_text(copied.path) == "outside secret"
+        renamed = await files.rename(
             fixture["escaped_file"],
             f"{base_dir}/parent-escape-mutate/renamed.txt",
         )
         assert renamed.path == f"{base_dir}/parent-escape-mutate/renamed.txt"
-        assert await sandbox.files.exists(fixture["outside_file"]) is False
-        assert await sandbox.files.read_text(renamed.path) == "outside secret"
-        await sandbox.files.write_text(fixture["escaped_file"], "remove me")
-        await sandbox.files.remove(fixture["escaped_file"])
+        assert await files.exists(fixture["outside_file"]) is False
+        assert await files.read_text(renamed.path) == "outside secret"
+        await files.write_text(fixture["escaped_file"], "remove me")
+        await files.remove(fixture["escaped_file"])
         outside_read = await sandbox.exec(
             _bash_exec(
                 f'if [ -e "{fixture["outside_file"]}" ]; then cat "{fixture["outside_file"]}"; else printf "__MISSING__"; fi'
@@ -485,18 +486,18 @@ async def test_async_sandbox_files_e2e():
             )
         )
         assert result.exit_code == 0
-        assert [entry.path for entry in await sandbox.files.list(link, depth=1)] == [
+        assert [entry.path for entry in await files.list(link, depth=1)] == [
             target_file
         ]
         seen = asyncio.get_running_loop().create_future()
 
         async def on_link_event(event):
-            if event.type == "write" and event.name == "file.txt" and not seen.done():
+            if event.type in {"create", "write"} and event.name == "file.txt" and not seen.done():
                 seen.set_result(event.name)
 
-        handle = await sandbox.files.watch_dir(link, on_link_event)
+        handle = await files.watch_dir(link, on_link_event)
         try:
-            await sandbox.files.write_text(
+            await files.write_text(
                 f"{target_dir}/file.txt", "watch through link"
             )
             assert await _await_future(seen) == "file.txt"
@@ -504,7 +505,7 @@ async def test_async_sandbox_files_e2e():
             await handle.stop()
 
         watch_dir = f"{base_dir}/watch"
-        await sandbox.files.make_dir(f"{watch_dir}/nested", parents=True)
+        await files.make_dir(f"{watch_dir}/nested", parents=True)
         direct_future = asyncio.get_running_loop().create_future()
         recursive_future = asyncio.get_running_loop().create_future()
 
@@ -524,15 +525,15 @@ async def test_async_sandbox_files_e2e():
             ):
                 recursive_future.set_result(event.name)
 
-        direct_handle = await sandbox.files.watch_dir(watch_dir, on_direct)
-        recursive_handle = await sandbox.files.watch_dir(
+        direct_handle = await files.watch_dir(watch_dir, on_direct)
+        recursive_handle = await files.watch_dir(
             watch_dir,
             on_recursive,
             recursive=True,
         )
         try:
-            await sandbox.files.write_text(f"{watch_dir}/direct.txt", "watch me")
-            await sandbox.files.write_text(
+            await files.write_text(f"{watch_dir}/direct.txt", "watch me")
+            await files.write_text(
                 f"{watch_dir}/nested/recursive.txt", "watch me too"
             )
             assert await _await_future(direct_future) == "direct.txt"
@@ -543,7 +544,7 @@ async def test_async_sandbox_files_e2e():
 
         await expect_hyperbrowser_error_async(
             "watch missing directory",
-            lambda: sandbox.files.watch_dir(
+            lambda: files.watch_dir(
                 f"{base_dir}/watch-missing", lambda event: None
             ),
             status_code=404,
@@ -553,10 +554,10 @@ async def test_async_sandbox_files_e2e():
         )
 
         invalid_file_path = f"{base_dir}/watch-invalid/file.txt"
-        await sandbox.files.write_text(invalid_file_path, "not a directory")
+        await files.write_text(invalid_file_path, "not a directory")
         await expect_hyperbrowser_error_async(
             "watch file path",
-            lambda: sandbox.files.watch_dir(invalid_file_path, lambda event: None),
+            lambda: files.watch_dir(invalid_file_path, lambda event: None),
             status_code=400,
             service="runtime",
             retryable=False,
@@ -564,7 +565,7 @@ async def test_async_sandbox_files_e2e():
         )
 
         path = f"{base_dir}/presign/file.txt"
-        upload = await sandbox.files.upload_url(path, one_time=True)
+        upload = await files.upload_url(path, one_time=True)
         assert upload.path == path
         assert upload.method == "PUT"
         upload_response = await asyncio.to_thread(
@@ -574,9 +575,9 @@ async def test_async_sandbox_files_e2e():
             body="presigned upload body",
         )
         assert upload_response.status_code == 200
-        assert await sandbox.files.read_text(path) == "presigned upload body"
+        assert await files.read_text(path) == "presigned upload body"
 
-        download = await sandbox.files.download_url(path, one_time=True)
+        download = await files.download_url(path, one_time=True)
         assert download.path == path
         assert download.method == "GET"
         download_response = await asyncio.to_thread(
@@ -588,7 +589,7 @@ async def test_async_sandbox_files_e2e():
         assert download_response.text == "presigned upload body"
 
         path = f"{base_dir}/presign-race/upload.txt"
-        upload = await sandbox.files.upload_url(path, one_time=True)
+        upload = await files.upload_url(path, one_time=True)
         first, second = await asyncio.gather(
             asyncio.to_thread(
                 fetch_signed_url,
@@ -604,11 +605,11 @@ async def test_async_sandbox_files_e2e():
             ),
         )
         assert sorted([first.status_code, second.status_code]) == [200, 401]
-        assert await sandbox.files.read_text(path) in {"first body", "second body"}
+        assert await files.read_text(path) in {"first body", "second body"}
 
         path = f"{base_dir}/presign-race/download.txt"
-        await sandbox.files.write_text(path, "download once")
-        download = await sandbox.files.download_url(path, one_time=True)
+        await files.write_text(path, "download once")
+        download = await files.download_url(path, one_time=True)
         first, second = await asyncio.gather(
             asyncio.to_thread(fetch_signed_url, download.url, method=download.method),
             asyncio.to_thread(fetch_signed_url, download.url, method=download.method),
@@ -619,10 +620,10 @@ async def test_async_sandbox_files_e2e():
         source = f"{base_dir}/rename-race/source.txt"
         left = f"{base_dir}/rename-race/left.txt"
         right = f"{base_dir}/rename-race/right.txt"
-        await sandbox.files.write_text(source, "race")
+        await files.write_text(source, "race")
         results = await asyncio.gather(
-            sandbox.files.rename(source, left),
-            sandbox.files.rename(source, right),
+            files.rename(source, left),
+            files.rename(source, right),
             return_exceptions=True,
         )
         fulfilled = [result for result in results if not isinstance(result, Exception)]
@@ -637,12 +638,12 @@ async def test_async_sandbox_files_e2e():
             retryable=False,
             message_includes_any=["not found", "no such file"],
         )
-        winner_path = left if await sandbox.files.exists(left) else right
-        assert await sandbox.files.read_text(winner_path) == "race"
+        winner_path = left if await files.exists(left) else right
+        assert await files.read_text(winner_path) == "race"
 
         await expect_hyperbrowser_error_async(
             "missing file read",
-            lambda: sandbox.files.read_text(f"{base_dir}/still-missing.txt"),
+            lambda: files.read_text(f"{base_dir}/still-missing.txt"),
             status_code=404,
             service="runtime",
             retryable=False,
@@ -650,7 +651,7 @@ async def test_async_sandbox_files_e2e():
         )
 
         try:
-            await sandbox.files.list(base_dir, depth=0)
+            await files.list(base_dir, depth=0)
         except ValueError as error:
             assert "depth should be at least one" in str(error)
         else:

--- a/tests/sandbox/e2e/test_async_lifecycle.py
+++ b/tests/sandbox/e2e/test_async_lifecycle.py
@@ -1,8 +1,10 @@
+import asyncio
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
 
+from hyperbrowser.exceptions import HyperbrowserError
 from hyperbrowser.models import CreateSandboxParams, SandboxRuntimeSession
 
 from tests.helpers.config import DEFAULT_IMAGE_NAME, create_async_client
@@ -16,6 +18,38 @@ from tests.helpers.sandbox import (
 )
 
 CUSTOM_IMAGE_NAME = "node"
+SNAPSHOT_SETTLE_DELAY_SECONDS = 30
+SNAPSHOT_CREATE_RETRY_TIMEOUT_SECONDS = 120
+SNAPSHOT_CREATE_RETRY_DELAY_SECONDS = 5
+
+
+def _is_snapshot_not_ready_error(error: BaseException) -> bool:
+    return (
+        isinstance(error, HyperbrowserError)
+        and error.status_code == 404
+        and "snapshot not found" in str(error).lower()
+    )
+
+
+async def _create_from_snapshot_eventually(
+    client, snapshot_name: str, snapshot_id: str
+):
+    deadline = asyncio.get_running_loop().time() + SNAPSHOT_CREATE_RETRY_TIMEOUT_SECONDS
+    while True:
+        try:
+            return await client.sandboxes.create(
+                CreateSandboxParams(
+                    snapshot_name=snapshot_name,
+                    snapshot_id=snapshot_id,
+                )
+            )
+        except Exception as error:
+            if (
+                asyncio.get_running_loop().time() >= deadline
+                or not _is_snapshot_not_ready_error(error)
+            ):
+                raise
+            await asyncio.sleep(SNAPSHOT_CREATE_RETRY_DELAY_SECONDS)
 
 
 @pytest.mark.anyio
@@ -133,11 +167,11 @@ async def test_async_sandbox_lifecycle_e2e():
         await wait_for_created_snapshot_async(
             client, custom_image_memory_snapshot.snapshot_id
         )
-        custom_snapshot_sandbox = await client.sandboxes.create(
-            CreateSandboxParams(
-                snapshot_name=custom_image_memory_snapshot.snapshot_name,
-                snapshot_id=custom_image_memory_snapshot.snapshot_id,
-            ),
+        await asyncio.sleep(SNAPSHOT_SETTLE_DELAY_SECONDS)
+        custom_snapshot_sandbox = await _create_from_snapshot_eventually(
+            client,
+            custom_image_memory_snapshot.snapshot_name,
+            custom_image_memory_snapshot.snapshot_id,
         )
         assert custom_snapshot_sandbox.id
         assert custom_snapshot_sandbox.status == "active"
@@ -236,11 +270,11 @@ async def test_async_sandbox_lifecycle_e2e():
         )
 
         await wait_for_created_snapshot_async(client, memory_snapshot.snapshot_id)
-        secondary = await client.sandboxes.create(
-            CreateSandboxParams(
-                snapshot_name=memory_snapshot.snapshot_name,
-                snapshot_id=memory_snapshot.snapshot_id,
-            ),
+        await asyncio.sleep(SNAPSHOT_SETTLE_DELAY_SECONDS)
+        secondary = await _create_from_snapshot_eventually(
+            client,
+            memory_snapshot.snapshot_name,
+            memory_snapshot.snapshot_id,
         )
         response = await secondary.stop()
         assert response.success is True

--- a/tests/sandbox/e2e/test_async_process.py
+++ b/tests/sandbox/e2e/test_async_process.py
@@ -37,6 +37,15 @@ async def test_async_sandbox_process_e2e():
 
         result = await sandbox.exec(
             SandboxExecParams(
+                command="echo process-use-shell-ignored",
+                use_shell=False,
+            )
+        )
+        assert result.exit_code == 0
+        assert "process-use-shell-ignored" in result.stdout
+
+        result = await sandbox.exec(
+            SandboxExecParams(
                 command="bash",
                 args=["-lc", "echo process-exec-fail 1>&2; exit 7"],
             )

--- a/tests/sandbox/e2e/test_files.py
+++ b/tests/sandbox/e2e/test_files.py
@@ -15,8 +15,8 @@ from tests.helpers.sandbox import (
 client = create_client()
 
 
-def _bash_exec(command: str) -> SandboxExecParams:
-    return SandboxExecParams(command="bash", args=["-lc", command])
+def _bash_exec(command: str, run_as: str = "root") -> SandboxExecParams:
+    return SandboxExecParams(command="bash", args=["-lc", command], run_as=run_as)
 
 
 def _read_stream_text(stream) -> str:
@@ -65,16 +65,17 @@ def test_sandbox_files_e2e():
     try:
         sandbox = client.sandboxes.create(default_sandbox_params("py-sdk-files"))
         wait_for_runtime_ready(sandbox)
+        files = sandbox.files.with_run_as("root")
 
-        assert sandbox.files.exists(f"{base_dir}/missing.txt") is False
+        assert files.exists(f"{base_dir}/missing.txt") is False
 
         path = f"{base_dir}/dirs/root"
-        assert sandbox.files.make_dir(path) is True
-        assert sandbox.files.make_dir(path) is False
+        assert files.make_dir(path) is True
+        assert files.make_dir(path) is False
 
         info_path = f"{base_dir}/info/hello.txt"
-        sandbox.files.write_text(info_path, "hello from sdk files")
-        info = sandbox.files.get_info(info_path)
+        files.write_text(info_path, "hello from sdk files")
+        info = files.get_info(info_path)
         assert info.name == "hello.txt"
         assert info.path == info_path
         assert info.type == "file"
@@ -86,18 +87,18 @@ def test_sandbox_files_e2e():
         assert info.modified_time is not None
 
         list_dir = f"{base_dir}/list"
-        sandbox.files.make_dir(f"{list_dir}/nested/inner", parents=True)
-        sandbox.files.write_text(f"{list_dir}/root.txt", "root")
-        sandbox.files.write_text(f"{list_dir}/nested/child.txt", "child")
-        sandbox.files.write_text(
+        files.make_dir(f"{list_dir}/nested/inner", parents=True)
+        files.write_text(f"{list_dir}/root.txt", "root")
+        files.write_text(f"{list_dir}/nested/child.txt", "child")
+        files.write_text(
             f"{list_dir}/nested/inner/grandchild.txt", "grandchild"
         )
 
-        depth_one = sandbox.files.list(list_dir, depth=1)
+        depth_one = files.list(list_dir, depth=1)
         assert [entry.name for entry in depth_one] == ["nested", "root.txt"]
         assert [entry.type for entry in depth_one] == ["dir", "file"]
 
-        depth_two = sandbox.files.list(list_dir, depth=2)
+        depth_two = files.list(list_dir, depth=2)
         assert [entry.path for entry in depth_two] == [
             f"{list_dir}/nested",
             f"{list_dir}/nested/child.txt",
@@ -108,27 +109,27 @@ def test_sandbox_files_e2e():
         symlink_dir = f"{base_dir}/list-symlink"
         target = f"{symlink_dir}/target.txt"
         link = f"{symlink_dir}/link.txt"
-        sandbox.files.make_dir(symlink_dir)
-        sandbox.files.write_text(target, "payload")
+        files.make_dir(symlink_dir)
+        files.write_text(target, "payload")
         result = sandbox.exec(_bash_exec(f'ln -sfn "{target}" "{link}"'))
         assert result.exit_code == 0
         link_entry = next(
             entry
-            for entry in sandbox.files.list(symlink_dir, depth=1)
+            for entry in files.list(symlink_dir, depth=1)
             if entry.path == link
         )
         assert link_entry.symlink_target == target
 
         symlink_target = f"{base_dir}/symlink/target.txt"
         symlink_link = f"{base_dir}/symlink/link.txt"
-        sandbox.files.write_text(symlink_target, "target")
+        files.write_text(symlink_target, "target")
         result = sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/symlink" && ln -sfn "{symlink_target}" "{symlink_link}"'
             )
         )
         assert result.exit_code == 0
-        assert sandbox.files.get_info(symlink_link).symlink_target == symlink_target
+        assert files.get_info(symlink_link).symlink_target == symlink_target
 
         broken_target = f"{base_dir}/symlink-broken/missing-target.txt"
         broken_link = f"{base_dir}/symlink-broken/link.txt"
@@ -138,28 +139,28 @@ def test_sandbox_files_e2e():
             )
         )
         assert result.exit_code == 0
-        assert sandbox.files.exists(broken_link) is True
-        assert sandbox.files.get_info(broken_link).symlink_target == broken_target
+        assert files.exists(broken_link) is True
+        assert files.get_info(broken_link).symlink_target == broken_target
 
         read_path = f"{base_dir}/read/readme.txt"
-        sandbox.files.write_text(read_path, "hello from sdk files")
-        assert sandbox.files.read(read_path) == "hello from sdk files"
+        files.write_text(read_path, "hello from sdk files")
+        assert files.read(read_path) == "hello from sdk files"
         assert (
-            sandbox.files.read(read_path, format="text", offset=6, length=4) == "from"
+            files.read(read_path, format="text", offset=6, length=4) == "from"
         )
-        assert sandbox.files.read(read_path, format="bytes") == b"hello from sdk files"
-        assert sandbox.files.read(read_path, format="blob") == b"hello from sdk files"
+        assert files.read(read_path, format="bytes") == b"hello from sdk files"
+        assert files.read(read_path, format="blob") == b"hello from sdk files"
         assert (
-            _read_stream_text(sandbox.files.read(read_path, format="stream"))
+            _read_stream_text(files.read(read_path, format="stream"))
             == "hello from sdk files"
         )
 
-        single = sandbox.files.write(f"{base_dir}/write/single.txt", "single file")
+        single = files.write(f"{base_dir}/write/single.txt", "single file")
         assert single.name == "single.txt"
         assert single.path == f"{base_dir}/write/single.txt"
-        assert sandbox.files.read_text(single.path) == "single file"
+        assert files.read_text(single.path) == "single file"
 
-        batch = sandbox.files.write(
+        batch = files.write(
             [
                 SandboxFileWriteEntry(
                     path=f"{base_dir}/write/batch-a.txt",
@@ -172,157 +173,157 @@ def test_sandbox_files_e2e():
             ]
         )
         assert [entry.name for entry in batch] == ["batch-a.txt", "batch-b.bin"]
-        assert sandbox.files.read_text(f"{base_dir}/write/batch-a.txt") == "batch-a"
-        assert sandbox.files.read_bytes(f"{base_dir}/write/batch-b.bin") == bytes(
+        assert files.read_text(f"{base_dir}/write/batch-a.txt") == "batch-a"
+        assert files.read_bytes(f"{base_dir}/write/batch-b.bin") == bytes(
             [1, 2, 3, 4]
         )
 
         text_path = f"{base_dir}/write-options/text.txt"
-        sandbox.files.write_text(text_path, "hello", mode="0640")
-        sandbox.files.write_text(text_path, " world", append=True)
-        assert sandbox.files.read_text(text_path) == "hello world"
-        assert sandbox.files.get_info(text_path).mode == 0o640
+        files.write_text(text_path, "hello", mode="0640")
+        files.write_text(text_path, " world", append=True)
+        assert files.read_text(text_path) == "hello world"
+        assert files.get_info(text_path).mode == 0o640
 
         bytes_path = f"{base_dir}/write-options/bytes.bin"
-        sandbox.files.write_bytes(bytes_path, bytes([1, 2]), mode="0600")
-        sandbox.files.write_bytes(bytes_path, bytes([3]), append=True)
-        assert sandbox.files.read_bytes(bytes_path) == bytes([1, 2, 3])
+        files.write_bytes(bytes_path, bytes([1, 2]), mode="0600")
+        files.write_bytes(bytes_path, bytes([3]), append=True)
+        assert files.read_bytes(bytes_path) == bytes([1, 2, 3])
 
         transfer_path = f"{base_dir}/transfer/upload.txt"
-        uploaded = sandbox.files.upload(transfer_path, "uploaded from sdk")
+        uploaded = files.upload(transfer_path, "uploaded from sdk")
         assert uploaded.bytes_written > 0
         assert (
-            sandbox.files.download(transfer_path).decode("utf-8") == "uploaded from sdk"
+            files.download(transfer_path).decode("utf-8") == "uploaded from sdk"
         )
 
         file_path = f"{base_dir}/rename/hello.txt"
         renamed_path = f"{base_dir}/rename/hello-renamed.txt"
-        sandbox.files.write_text(file_path, "rename me")
-        renamed = sandbox.files.rename(file_path, renamed_path)
+        files.write_text(file_path, "rename me")
+        renamed = files.rename(file_path, renamed_path)
         assert renamed.path == renamed_path
-        assert sandbox.files.exists(file_path) is False
-        assert sandbox.files.read_text(renamed_path) == "rename me"
+        assert files.exists(file_path) is False
+        assert files.read_text(renamed_path) == "rename me"
 
         link_path = f"{base_dir}/rename/hello-link.txt"
         copied_link_path = f"{base_dir}/rename/hello-link-copy.txt"
         renamed_link_path = f"{base_dir}/rename/hello-link-renamed.txt"
         result = sandbox.exec(_bash_exec(f'ln -sfn "{renamed_path}" "{link_path}"'))
         assert result.exit_code == 0
-        copied_link = sandbox.files.copy(source=link_path, destination=copied_link_path)
+        copied_link = files.copy(source=link_path, destination=copied_link_path)
         assert copied_link.path == copied_link_path
-        assert sandbox.files.get_info(copied_link_path).symlink_target == renamed_path
-        renamed_link = sandbox.files.rename(copied_link_path, renamed_link_path)
+        assert files.get_info(copied_link_path).symlink_target == renamed_path
+        renamed_link = files.rename(copied_link_path, renamed_link_path)
         assert renamed_link.path == renamed_link_path
-        assert sandbox.files.get_info(renamed_link_path).symlink_target == renamed_path
+        assert files.get_info(renamed_link_path).symlink_target == renamed_path
 
         target_dir = f"{base_dir}/rename-dir/target-dir"
         link_dir = f"{base_dir}/rename-dir/link-dir"
         renamed_link_dir = f"{base_dir}/rename-dir/link-dir-renamed"
-        sandbox.files.make_dir(target_dir)
-        sandbox.files.write_text(f"{target_dir}/child.txt", "child")
+        files.make_dir(target_dir)
+        files.write_text(f"{target_dir}/child.txt", "child")
         result = sandbox.exec(_bash_exec(f'ln -sfn "{target_dir}" "{link_dir}"'))
         assert result.exit_code == 0
-        renamed = sandbox.files.rename(link_dir, renamed_link_dir)
+        renamed = files.rename(link_dir, renamed_link_dir)
         assert renamed.path == renamed_link_dir
-        assert sandbox.files.get_info(renamed_link_dir).symlink_target == target_dir
+        assert files.get_info(renamed_link_dir).symlink_target == target_dir
         assert [
-            entry.path for entry in sandbox.files.list(renamed_link_dir, depth=1)
+            entry.path for entry in files.list(renamed_link_dir, depth=1)
         ] == [f"{target_dir}/child.txt"]
 
         source_dir = f"{base_dir}/copy-tree/source"
         nested_dir = f"{source_dir}/nested"
         nested_target = f"{nested_dir}/target.txt"
         destination_dir = f"{base_dir}/copy-tree/destination"
-        sandbox.files.make_dir(nested_dir)
-        sandbox.files.write_text(nested_target, "payload")
+        files.make_dir(nested_dir)
+        files.write_text(nested_target, "payload")
         result = sandbox.exec(
             _bash_exec(f'cd "{nested_dir}" && ln -sfn "target.txt" "link.txt"')
         )
         assert result.exit_code == 0
-        sandbox.files.copy(
+        files.copy(
             source=source_dir, destination=destination_dir, recursive=True
         )
         copied_target = f"{destination_dir}/nested/target.txt"
         copied_link = f"{destination_dir}/nested/link.txt"
-        assert sandbox.files.read_text(copied_target) == "payload"
-        assert sandbox.files.get_info(copied_link).symlink_target == copied_target
+        assert files.read_text(copied_target) == "payload"
+        assert files.get_info(copied_link).symlink_target == copied_target
 
         loop_dir = f"{base_dir}/loop-list"
         loop_nested_dir = f"{loop_dir}/nested"
-        sandbox.files.make_dir(loop_nested_dir)
-        sandbox.files.write_text(f"{loop_nested_dir}/child.txt", "payload")
+        files.make_dir(loop_nested_dir)
+        files.write_text(f"{loop_nested_dir}/child.txt", "payload")
         result = sandbox.exec(_bash_exec(f'cd "{loop_nested_dir}" && ln -sfn .. loop'))
         assert result.exit_code == 0
-        loop_entries = sandbox.files.list(loop_dir, depth=4)
+        loop_entries = files.list(loop_dir, depth=4)
         loop_paths = [entry.path for entry in loop_entries]
         assert f"{loop_nested_dir}/loop" in loop_paths
         assert not any("/loop/" in path for path in loop_paths)
         assert (
-            sandbox.files.get_info(f"{loop_nested_dir}/loop").symlink_target == loop_dir
+            files.get_info(f"{loop_nested_dir}/loop").symlink_target == loop_dir
         )
 
         source_dir = f"{base_dir}/loop-copy/source"
         nested_dir = f"{source_dir}/nested"
-        sandbox.files.make_dir(nested_dir)
-        sandbox.files.write_text(f"{nested_dir}/child.txt", "payload")
+        files.make_dir(nested_dir)
+        files.write_text(f"{nested_dir}/child.txt", "payload")
         result = sandbox.exec(_bash_exec(f'cd "{nested_dir}" && ln -sfn .. loop'))
         assert result.exit_code == 0
         destination_dir = f"{base_dir}/loop-copy/destination"
-        sandbox.files.copy(
+        files.copy(
             source=source_dir, destination=destination_dir, recursive=True
         )
         copied_loop = f"{destination_dir}/nested/loop"
-        assert sandbox.files.get_info(copied_loop).symlink_target == destination_dir
+        assert files.get_info(copied_loop).symlink_target == destination_dir
         assert not any(
             "/loop/" in entry.path
-            for entry in sandbox.files.list(destination_dir, depth=4)
+            for entry in files.list(destination_dir, depth=4)
         )
 
         source = f"{base_dir}/copy-overwrite/source.txt"
         existing_target = f"{base_dir}/copy-overwrite/existing-target.txt"
         destination_link = f"{base_dir}/copy-overwrite/destination-link.txt"
-        sandbox.files.write_text(source, "source payload")
-        sandbox.files.write_text(existing_target, "existing target")
+        files.write_text(source, "source payload")
+        files.write_text(existing_target, "existing target")
         result = sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/copy-overwrite" && ln -sfn "{existing_target}" "{destination_link}"'
             )
         )
         assert result.exit_code == 0
-        sandbox.files.copy(source=source, destination=destination_link, overwrite=True)
-        assert sandbox.files.read_text(destination_link) == "source payload"
-        assert sandbox.files.read_text(existing_target) == "existing target"
-        assert sandbox.files.get_info(destination_link).symlink_target is None
+        files.copy(source=source, destination=destination_link, overwrite=True)
+        assert files.read_text(destination_link) == "source payload"
+        assert files.read_text(existing_target) == "existing target"
+        assert files.get_info(destination_link).symlink_target is None
 
         move_source = f"{base_dir}/move-overwrite/source.txt"
         move_existing_target = f"{base_dir}/move-overwrite/existing-target.txt"
         move_destination_link = f"{base_dir}/move-overwrite/destination-link.txt"
-        sandbox.files.write_text(move_source, "move source payload")
-        sandbox.files.write_text(move_existing_target, "move existing target")
+        files.write_text(move_source, "move source payload")
+        files.write_text(move_existing_target, "move existing target")
         result = sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/move-overwrite" && ln -sfn "{move_existing_target}" "{move_destination_link}"'
             )
         )
         assert result.exit_code == 0
-        sandbox.files.move(
+        files.move(
             source=move_source,
             destination=move_destination_link,
             overwrite=True,
         )
-        assert sandbox.files.read_text(move_destination_link) == "move source payload"
-        assert sandbox.files.read_text(move_existing_target) == "move existing target"
-        assert sandbox.files.get_info(move_destination_link).symlink_target is None
-        assert sandbox.files.exists(move_source) is False
+        assert files.read_text(move_destination_link) == "move source payload"
+        assert files.read_text(move_existing_target) == "move existing target"
+        assert files.get_info(move_destination_link).symlink_target is None
+        assert files.exists(move_source) is False
 
         chmod_path = f"{base_dir}/chmod/file.txt"
-        sandbox.files.write_text(chmod_path, "chmod me")
-        sandbox.files.chmod(path=chmod_path, mode="0640")
-        assert sandbox.files.get_info(chmod_path).mode == 0o640
+        files.write_text(chmod_path, "chmod me")
+        files.chmod(path=chmod_path, mode="0640")
+        assert files.get_info(chmod_path).mode == 0o640
         try:
             expect_hyperbrowser_error(
                 "file chown",
-                lambda: sandbox.files.chown(path=chmod_path, uid=0, gid=0),
+                lambda: files.chown(path=chmod_path, uid=0, gid=0),
                 status_code=400,
                 service="runtime",
                 retryable=False,
@@ -331,75 +332,75 @@ def test_sandbox_files_e2e():
         except AssertionError as error:
             if "expected HyperbrowserError, but call succeeded" not in str(error):
                 raise
-            assert sandbox.files.get_info(chmod_path).name == "file.txt"
+            assert files.get_info(chmod_path).name == "file.txt"
 
         remove_path = f"{base_dir}/remove/file.txt"
-        sandbox.files.write_text(remove_path, "remove me")
-        sandbox.files.remove(remove_path)
-        assert sandbox.files.exists(remove_path) is False
-        sandbox.files.remove(remove_path)
-        sandbox.files.remove(f"{base_dir}/remove", recursive=True)
-        assert sandbox.files.exists(f"{base_dir}/remove") is False
+        files.write_text(remove_path, "remove me")
+        files.remove(remove_path)
+        assert files.exists(remove_path) is False
+        files.remove(remove_path)
+        files.remove(f"{base_dir}/remove", recursive=True)
+        assert files.exists(f"{base_dir}/remove") is False
 
         target = f"{base_dir}/remove-link/target.txt"
         link = f"{base_dir}/remove-link/link.txt"
-        sandbox.files.write_text(target, "keep me")
+        files.write_text(target, "keep me")
         result = sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/remove-link" && ln -sfn "{target}" "{link}"'
             )
         )
         assert result.exit_code == 0
-        sandbox.files.remove(link)
-        assert sandbox.files.exists(link) is False
-        assert sandbox.files.read_text(target) == "keep me"
+        files.remove(link)
+        assert files.exists(link) is False
+        assert files.read_text(target) == "keep me"
 
         target_dir = f"{base_dir}/remove-recursive/target-dir"
         target_file = f"{target_dir}/child.txt"
         link_dir = f"{base_dir}/remove-recursive/link-dir"
-        sandbox.files.make_dir(target_dir)
-        sandbox.files.write_text(target_file, "keep tree")
+        files.make_dir(target_dir)
+        files.write_text(target_file, "keep tree")
         result = sandbox.exec(
             _bash_exec(
                 f'mkdir -p "{base_dir}/remove-recursive" && ln -sfn "{target_dir}" "{link_dir}"'
             )
         )
         assert result.exit_code == 0
-        sandbox.files.remove(link_dir, recursive=True)
-        assert sandbox.files.exists(link_dir) is False
-        assert sandbox.files.read_text(target_file) == "keep tree"
+        files.remove(link_dir, recursive=True)
+        assert files.exists(link_dir) is False
+        assert files.read_text(target_file) == "keep tree"
 
         link = f"{base_dir}/escape/file-link"
         result = sandbox.exec(
             _bash_exec(f'mkdir -p "{base_dir}/escape" && ln -sfn /etc/hosts "{link}"')
         )
         assert result.exit_code == 0
-        text = sandbox.files.read_text(link)
+        text = files.read_text(link)
         assert "localhost" in text
-        assert "localhost" in sandbox.files.download(link).decode("utf-8")
+        assert "localhost" in files.download(link).decode("utf-8")
 
         fixture = _create_parent_symlink_escape_fixture(
             sandbox, base_dir, "parent-escape-read"
         )
-        assert sandbox.files.read_text(fixture["escaped_file"]) == "outside secret"
+        assert files.read_text(fixture["escaped_file"]) == "outside secret"
         assert (
-            sandbox.files.download(fixture["escaped_file"]).decode("utf-8")
+            files.download(fixture["escaped_file"]).decode("utf-8")
             == "outside secret"
         )
         assert [
-            entry.path for entry in sandbox.files.list(fixture["link_dir"], depth=1)
+            entry.path for entry in files.list(fixture["link_dir"], depth=1)
         ] == [f"{fixture['outside_dir']}/secret.txt"]
         seen = Queue(maxsize=1)
-        handle = sandbox.files.watch_dir(
+        handle = files.watch_dir(
             fixture["link_dir"],
             lambda event: (
                 seen.put_nowait(event.name)
-                if event.type == "write" and event.name == "fresh.txt"
+                if event.type in {"create", "write"} and event.name == "fresh.txt"
                 else None
             ),
         )
         try:
-            sandbox.files.write_text(
+            files.write_text(
                 f"{fixture['outside_dir']}/fresh.txt", "watch parent link"
             )
             assert _await_queue_value(seen) == "fresh.txt"
@@ -409,24 +410,24 @@ def test_sandbox_files_e2e():
         fixture = _create_parent_symlink_escape_fixture(
             sandbox, base_dir, "parent-escape-mutate"
         )
-        info = sandbox.files.get_info(fixture["escaped_file"])
+        info = files.get_info(fixture["escaped_file"])
         assert info.type == "file"
         assert info.size == len("outside secret")
-        copied = sandbox.files.copy(
+        copied = files.copy(
             source=fixture["escaped_file"],
             destination=f"{base_dir}/parent-escape-mutate/copied.txt",
         )
         assert copied.path == f"{base_dir}/parent-escape-mutate/copied.txt"
-        assert sandbox.files.read_text(copied.path) == "outside secret"
-        renamed = sandbox.files.rename(
+        assert files.read_text(copied.path) == "outside secret"
+        renamed = files.rename(
             fixture["escaped_file"],
             f"{base_dir}/parent-escape-mutate/renamed.txt",
         )
         assert renamed.path == f"{base_dir}/parent-escape-mutate/renamed.txt"
-        assert sandbox.files.exists(fixture["outside_file"]) is False
-        assert sandbox.files.read_text(renamed.path) == "outside secret"
-        sandbox.files.write_text(fixture["escaped_file"], "remove me")
-        sandbox.files.remove(fixture["escaped_file"])
+        assert files.exists(fixture["outside_file"]) is False
+        assert files.read_text(renamed.path) == "outside secret"
+        files.write_text(fixture["escaped_file"], "remove me")
+        files.remove(fixture["escaped_file"])
         outside_read = sandbox.exec(
             _bash_exec(
                 f'if [ -e "{fixture["outside_file"]}" ]; then cat "{fixture["outside_file"]}"; else printf "__MISSING__"; fi'
@@ -444,48 +445,48 @@ def test_sandbox_files_e2e():
             )
         )
         assert result.exit_code == 0
-        assert [entry.path for entry in sandbox.files.list(link, depth=1)] == [
+        assert [entry.path for entry in files.list(link, depth=1)] == [
             target_file
         ]
         seen = Queue(maxsize=1)
-        handle = sandbox.files.watch_dir(
+        handle = files.watch_dir(
             link,
             lambda event: (
                 seen.put_nowait(event.name)
-                if event.type == "write" and event.name == "file.txt"
+                if event.type in {"create", "write"} and event.name == "file.txt"
                 else None
             ),
         )
         try:
-            sandbox.files.write_text(f"{target_dir}/file.txt", "watch through link")
+            files.write_text(f"{target_dir}/file.txt", "watch through link")
             assert _await_queue_value(seen) == "file.txt"
         finally:
             handle.stop()
 
         watch_dir = f"{base_dir}/watch"
-        sandbox.files.make_dir(f"{watch_dir}/nested", parents=True)
+        files.make_dir(f"{watch_dir}/nested", parents=True)
         direct_event = Queue(maxsize=1)
         recursive_event = Queue(maxsize=1)
-        direct_handle = sandbox.files.watch_dir(
+        direct_handle = files.watch_dir(
             watch_dir,
             lambda event: (
                 direct_event.put_nowait(event.name)
-                if event.type == "write" and event.name == "direct.txt"
+                if event.type in {"create", "write"} and event.name == "direct.txt"
                 else None
             ),
         )
-        recursive_handle = sandbox.files.watch_dir(
+        recursive_handle = files.watch_dir(
             watch_dir,
             lambda event: (
                 recursive_event.put_nowait(event.name)
-                if event.type == "write" and event.name == "nested/recursive.txt"
+                if event.type in {"create", "write"} and event.name == "nested/recursive.txt"
                 else None
             ),
             recursive=True,
         )
         try:
-            sandbox.files.write_text(f"{watch_dir}/direct.txt", "watch me")
-            sandbox.files.write_text(
+            files.write_text(f"{watch_dir}/direct.txt", "watch me")
+            files.write_text(
                 f"{watch_dir}/nested/recursive.txt", "watch me too"
             )
             assert _await_queue_value(direct_event) == "direct.txt"
@@ -496,7 +497,7 @@ def test_sandbox_files_e2e():
 
         expect_hyperbrowser_error(
             "watch missing directory",
-            lambda: sandbox.files.watch_dir(
+            lambda: files.watch_dir(
                 f"{base_dir}/watch-missing", lambda event: None
             ),
             status_code=404,
@@ -506,10 +507,10 @@ def test_sandbox_files_e2e():
         )
 
         invalid_file_path = f"{base_dir}/watch-invalid/file.txt"
-        sandbox.files.write_text(invalid_file_path, "not a directory")
+        files.write_text(invalid_file_path, "not a directory")
         expect_hyperbrowser_error(
             "watch file path",
-            lambda: sandbox.files.watch_dir(invalid_file_path, lambda event: None),
+            lambda: files.watch_dir(invalid_file_path, lambda event: None),
             status_code=400,
             service="runtime",
             retryable=False,
@@ -517,7 +518,7 @@ def test_sandbox_files_e2e():
         )
 
         path = f"{base_dir}/presign/file.txt"
-        upload = sandbox.files.upload_url(path, one_time=True)
+        upload = files.upload_url(path, one_time=True)
         assert upload.path == path
         assert upload.method == "PUT"
         upload_response = fetch_signed_url(
@@ -526,9 +527,9 @@ def test_sandbox_files_e2e():
             body="presigned upload body",
         )
         assert upload_response.status_code == 200
-        assert sandbox.files.read_text(path) == "presigned upload body"
+        assert files.read_text(path) == "presigned upload body"
 
-        download = sandbox.files.download_url(path, one_time=True)
+        download = files.download_url(path, one_time=True)
         assert download.path == path
         assert download.method == "GET"
         download_response = fetch_signed_url(download.url, method=download.method)
@@ -536,7 +537,7 @@ def test_sandbox_files_e2e():
         assert download_response.text == "presigned upload body"
 
         path = f"{base_dir}/presign-race/upload.txt"
-        upload = sandbox.files.upload_url(path, one_time=True)
+        upload = files.upload_url(path, one_time=True)
         with ThreadPoolExecutor(max_workers=2) as executor:
             first_future = executor.submit(
                 fetch_signed_url,
@@ -553,11 +554,11 @@ def test_sandbox_files_e2e():
             first = first_future.result()
             second = second_future.result()
         assert sorted([first.status_code, second.status_code]) == [200, 401]
-        assert sandbox.files.read_text(path) in {"first body", "second body"}
+        assert files.read_text(path) in {"first body", "second body"}
 
         path = f"{base_dir}/presign-race/download.txt"
-        sandbox.files.write_text(path, "download once")
-        download = sandbox.files.download_url(path, one_time=True)
+        files.write_text(path, "download once")
+        download = files.download_url(path, one_time=True)
         with ThreadPoolExecutor(max_workers=2) as executor:
             first_future = executor.submit(
                 fetch_signed_url, download.url, method=download.method
@@ -573,11 +574,11 @@ def test_sandbox_files_e2e():
         source = f"{base_dir}/rename-race/source.txt"
         left = f"{base_dir}/rename-race/left.txt"
         right = f"{base_dir}/rename-race/right.txt"
-        sandbox.files.write_text(source, "race")
+        files.write_text(source, "race")
         with ThreadPoolExecutor(max_workers=2) as executor:
             futures = [
-                executor.submit(sandbox.files.rename, source, left),
-                executor.submit(sandbox.files.rename, source, right),
+                executor.submit(files.rename, source, left),
+                executor.submit(files.rename, source, right),
             ]
         results = []
         for future in futures:
@@ -597,12 +598,12 @@ def test_sandbox_files_e2e():
             retryable=False,
             message_includes_any=["not found", "no such file"],
         )
-        winner_path = left if sandbox.files.exists(left) else right
-        assert sandbox.files.read_text(winner_path) == "race"
+        winner_path = left if files.exists(left) else right
+        assert files.read_text(winner_path) == "race"
 
         expect_hyperbrowser_error(
             "missing file read",
-            lambda: sandbox.files.read_text(f"{base_dir}/still-missing.txt"),
+            lambda: files.read_text(f"{base_dir}/still-missing.txt"),
             status_code=404,
             service="runtime",
             retryable=False,
@@ -610,7 +611,7 @@ def test_sandbox_files_e2e():
         )
 
         try:
-            sandbox.files.list(base_dir, depth=0)
+            files.list(base_dir, depth=0)
         except ValueError as error:
             assert "depth should be at least one" in str(error)
         else:

--- a/tests/sandbox/e2e/test_lifecycle.py
+++ b/tests/sandbox/e2e/test_lifecycle.py
@@ -1,6 +1,8 @@
+import time
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
+from hyperbrowser.exceptions import HyperbrowserError
 from hyperbrowser.models import CreateSandboxParams, SandboxRuntimeSession
 
 from tests.helpers.config import DEFAULT_IMAGE_NAME, create_client
@@ -16,6 +18,33 @@ from tests.helpers.sandbox import (
 client = create_client()
 
 CUSTOM_IMAGE_NAME = "node"
+SNAPSHOT_SETTLE_DELAY_SECONDS = 30
+SNAPSHOT_CREATE_RETRY_TIMEOUT_SECONDS = 120
+SNAPSHOT_CREATE_RETRY_DELAY_SECONDS = 5
+
+
+def _is_snapshot_not_ready_error(error: BaseException) -> bool:
+    return (
+        isinstance(error, HyperbrowserError)
+        and error.status_code == 404
+        and "snapshot not found" in str(error).lower()
+    )
+
+
+def _create_from_snapshot_eventually(snapshot_name: str, snapshot_id: str):
+    deadline = time.time() + SNAPSHOT_CREATE_RETRY_TIMEOUT_SECONDS
+    while True:
+        try:
+            return client.sandboxes.create(
+                CreateSandboxParams(
+                    snapshot_name=snapshot_name,
+                    snapshot_id=snapshot_id,
+                )
+            )
+        except Exception as error:
+            if time.time() >= deadline or not _is_snapshot_not_ready_error(error):
+                raise
+            time.sleep(SNAPSHOT_CREATE_RETRY_DELAY_SECONDS)
 
 
 def test_sandbox_lifecycle_e2e():
@@ -125,11 +154,10 @@ def test_sandbox_lifecycle_e2e():
         assert custom_image_memory_snapshot.image_namespace == custom_image["namespace"]
 
         wait_for_created_snapshot(client, custom_image_memory_snapshot.snapshot_id)
-        custom_snapshot_sandbox = client.sandboxes.create(
-            CreateSandboxParams(
-                snapshot_name=custom_image_memory_snapshot.snapshot_name,
-                snapshot_id=custom_image_memory_snapshot.snapshot_id,
-            )
+        time.sleep(SNAPSHOT_SETTLE_DELAY_SECONDS)
+        custom_snapshot_sandbox = _create_from_snapshot_eventually(
+            custom_image_memory_snapshot.snapshot_name,
+            custom_image_memory_snapshot.snapshot_id,
         )
         assert custom_snapshot_sandbox.id
         assert custom_snapshot_sandbox.status == "active"
@@ -228,11 +256,10 @@ def test_sandbox_lifecycle_e2e():
         )
 
         wait_for_created_snapshot(client, memory_snapshot.snapshot_id)
-        secondary = client.sandboxes.create(
-            CreateSandboxParams(
-                snapshot_name=memory_snapshot.snapshot_name,
-                snapshot_id=memory_snapshot.snapshot_id,
-            )
+        time.sleep(SNAPSHOT_SETTLE_DELAY_SECONDS)
+        secondary = _create_from_snapshot_eventually(
+            memory_snapshot.snapshot_name,
+            memory_snapshot.snapshot_id,
         )
         response = secondary.stop()
         assert response.success is True

--- a/tests/sandbox/e2e/test_process.py
+++ b/tests/sandbox/e2e/test_process.py
@@ -33,6 +33,15 @@ def test_sandbox_process_e2e():
 
         result = sandbox.exec(
             SandboxExecParams(
+                command="echo process-use-shell-ignored",
+                use_shell=False,
+            )
+        )
+        assert result.exit_code == 0
+        assert "process-use-shell-ignored" in result.stdout
+
+        result = sandbox.exec(
+            SandboxExecParams(
                 command="bash",
                 args=["-lc", "echo process-exec-fail 1>&2; exit 7"],
             )

--- a/tests/test_sandbox_wire_contract.py
+++ b/tests/test_sandbox_wire_contract.py
@@ -709,7 +709,8 @@ def test_sync_sandbox_runtime_apis_use_expected_wire_keys():
 
     processes = SandboxProcessesApi(transport)
     process_input = SandboxExecParams(
-        command="echo hi",
+        command="echo",
+        args=["hi world"],
         timeout_ms=500,
         timeout_sec=7,
         run_as="root",
@@ -762,18 +763,16 @@ def test_sync_sandbox_runtime_apis_use_expected_wire_keys():
     )
 
     assert transport.calls[0]["json_body"] == {
-        "command": "echo hi",
+        "command": "echo 'hi world'",
         "timeoutMs": 500,
         "timeout_sec": 7,
         "runAs": "root",
-        "useShell": True,
     }
     assert transport.calls[1]["json_body"] == {
-        "command": "echo hi",
+        "command": "echo 'hi world'",
         "timeoutMs": 500,
         "timeout_sec": 7,
         "runAs": "root",
-        "useShell": True,
     }
     assert transport.calls[2]["json_body"] == {
         "timeoutMs": 250,
@@ -987,7 +986,8 @@ async def test_async_sandbox_runtime_apis_use_expected_wire_keys():
 
     processes = AsyncSandboxProcessesApi(transport)
     process_input = SandboxExecParams(
-        command="echo hi",
+        command="echo",
+        args=["hi world"],
         timeout_ms=500,
         timeout_sec=7,
         run_as="root",
@@ -1040,18 +1040,16 @@ async def test_async_sandbox_runtime_apis_use_expected_wire_keys():
     )
 
     assert transport.calls[0]["json_body"] == {
-        "command": "echo hi",
+        "command": "echo 'hi world'",
         "timeoutMs": 500,
         "timeout_sec": 7,
         "runAs": "root",
-        "useShell": True,
     }
     assert transport.calls[1]["json_body"] == {
-        "command": "echo hi",
+        "command": "echo 'hi world'",
         "timeoutMs": 500,
         "timeout_sec": 7,
         "runAs": "root",
-        "useShell": True,
     }
     assert transport.calls[2]["json_body"] == {
         "timeoutMs": 250,

--- a/tests/test_sandbox_wire_contract.py
+++ b/tests/test_sandbox_wire_contract.py
@@ -27,6 +27,7 @@ from hyperbrowser.client.managers.sync_manager.sandboxes.sandbox_terminal import
 )
 from hyperbrowser.models import (
     CreateSandboxParams,
+    SandboxDetail,
     SandboxExposeParams,
     SandboxExecParams,
     SandboxFileWriteEntry,
@@ -519,11 +520,13 @@ def test_sandbox_request_models_serialize_expected_wire_keys():
         command="echo hi",
         timeout_ms=500,
         timeout_sec=7,
+        run_as="root",
         use_shell=True,
     ).model_dump(by_alias=True, exclude_none=True) == {
         "command": "echo hi",
         "timeoutMs": 500,
         "timeout_sec": 7,
+        "runAs": "root",
         "useShell": True,
     }
 
@@ -709,6 +712,7 @@ def test_sync_sandbox_runtime_apis_use_expected_wire_keys():
         command="echo hi",
         timeout_ms=500,
         timeout_sec=7,
+        run_as="root",
         use_shell=True,
     )
 
@@ -761,12 +765,14 @@ def test_sync_sandbox_runtime_apis_use_expected_wire_keys():
         "command": "echo hi",
         "timeoutMs": 500,
         "timeout_sec": 7,
+        "runAs": "root",
         "useShell": True,
     }
     assert transport.calls[1]["json_body"] == {
         "command": "echo hi",
         "timeoutMs": 500,
         "timeout_sec": 7,
+        "runAs": "root",
         "useShell": True,
     }
     assert transport.calls[2]["json_body"] == {
@@ -819,6 +825,66 @@ def test_sync_sandbox_runtime_apis_use_expected_wire_keys():
         "to": "/tmp/destination.txt",
         "overwrite": True,
     }
+
+
+def test_sync_sandbox_process_string_calls_support_run_as():
+    transport = RecordingTransport()
+    processes = SandboxProcessesApi(transport)
+
+    processes.exec(
+        "whoami",
+        cwd="/tmp",
+        env={"FOO": "bar"},
+        timeout_ms=500,
+        timeout_sec=7,
+        run_as="root",
+    )
+    processes.start(
+        "sleep 30",
+        cwd="/tmp",
+        run_as="root",
+    )
+
+    assert transport.calls[0]["json_body"] == {
+        "command": "whoami",
+        "cwd": "/tmp",
+        "env": {"FOO": "bar"},
+        "timeoutMs": 500,
+        "timeout_sec": 7,
+        "runAs": "root",
+    }
+    assert transport.calls[1]["json_body"] == {
+        "command": "sleep 30",
+        "cwd": "/tmp",
+        "runAs": "root",
+    }
+
+
+def test_sync_sandbox_handle_exec_string_call_supports_run_as(monkeypatch):
+    manager = SandboxManager(FakeSyncClient())
+    sandbox = manager.attach(SandboxDetail(**SANDBOX_DETAIL_PAYLOAD))
+    calls = []
+
+    def fake_exec(input, **kwargs):
+        calls.append((input, kwargs))
+        return PROCESS_RESULT_PAYLOAD["result"]
+
+    monkeypatch.setattr(sandbox.processes, "exec", fake_exec)
+
+    sandbox.exec("whoami", run_as="root")
+
+    assert calls == [
+        (
+            "whoami",
+            {
+                "cwd": None,
+                "env": None,
+                "timeout_ms": None,
+                "timeout_sec": None,
+                "run_as": "root",
+            },
+        )
+    ]
 
 
 @pytest.mark.anyio
@@ -924,6 +990,7 @@ async def test_async_sandbox_runtime_apis_use_expected_wire_keys():
         command="echo hi",
         timeout_ms=500,
         timeout_sec=7,
+        run_as="root",
         use_shell=True,
     )
 
@@ -976,12 +1043,14 @@ async def test_async_sandbox_runtime_apis_use_expected_wire_keys():
         "command": "echo hi",
         "timeoutMs": 500,
         "timeout_sec": 7,
+        "runAs": "root",
         "useShell": True,
     }
     assert transport.calls[1]["json_body"] == {
         "command": "echo hi",
         "timeoutMs": 500,
         "timeout_sec": 7,
+        "runAs": "root",
         "useShell": True,
     }
     assert transport.calls[2]["json_body"] == {
@@ -1033,6 +1102,40 @@ async def test_async_sandbox_runtime_apis_use_expected_wire_keys():
         "from": "/tmp/source.txt",
         "to": "/tmp/destination.txt",
         "overwrite": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_async_sandbox_process_string_calls_support_run_as():
+    transport = AsyncRecordingTransport()
+    processes = AsyncSandboxProcessesApi(transport)
+
+    await processes.exec(
+        "whoami",
+        cwd="/tmp",
+        env={"FOO": "bar"},
+        timeout_ms=500,
+        timeout_sec=7,
+        run_as="root",
+    )
+    await processes.start(
+        "sleep 30",
+        cwd="/tmp",
+        run_as="root",
+    )
+
+    assert transport.calls[0]["json_body"] == {
+        "command": "whoami",
+        "cwd": "/tmp",
+        "env": {"FOO": "bar"},
+        "timeoutMs": 500,
+        "timeout_sec": 7,
+        "runAs": "root",
+    }
+    assert transport.calls[1]["json_body"] == {
+        "command": "sleep 30",
+        "cwd": "/tmp",
+        "runAs": "root",
     }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.14"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how process commands are serialized (quoting/flattening `args` and dropping `use_shell`) and adds `runAs` propagation across runtime file/process APIs, which could affect command execution and permissions behavior.
> 
> **Overview**
> Adds first-class *user impersonation* support to sandbox runtime calls by introducing `run_as`/`runAs` on `SandboxExecParams`, threading it through `SandboxHandle.exec`, and providing `SandboxFilesApi.with_run_as()` to apply `runAs` to all file requests.
> 
> Refactors process execution to accept either a command string or `SandboxExecParams` plus optional overrides (`cwd`, `env`, timeouts, `run_as`), normalizing legacy fields by shell-quoting and folding `args` into `command` while omitting `args`/`useShell` from the wire payload.
> 
> Updates E2E/contract tests to use the new `with_run_as("root")` pattern, to accept `create` events in file watching assertions, and to add retry/backoff when creating sandboxes from newly-created snapshots; bumps SDK version to `0.90.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd38cb483f36636d5516dde60a80ae4ea4be14ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->