### PR TITLE
fix route parsing

### DIFF
--- a/hyperbrowser/client/managers/sandboxes/shared.py
+++ b/hyperbrowser/client/managers/sandboxes/shared.py
@@ -84,13 +84,40 @@ def _normalize_exec_params(
     return _normalize_legacy_process_fields(normalized)
 
 
+def _runtime_session_id_from_path(raw_path: str) -> Optional[str]:
+    segments = [
+        segment for segment in raw_path.strip().strip("/").split("/") if segment
+    ]
+    if len(segments) < 2 or segments[0] != "sandbox" or not segments[1]:
+        return None
+    return segments[1]
+
+
+def _resolve_sandbox_runtime_session_host(runtime, base_url) -> str:
+    session_id_from_base_path = _runtime_session_id_from_path(base_url.path)
+    if session_id_from_base_path and base_url.hostname:
+        return f"{session_id_from_base_path}.{base_url.hostname}"
+
+    runtime_host = str(getattr(runtime, "host", "") or "").strip()
+    if runtime_host:
+        parsed_host = urlsplit(runtime_host)
+        if parsed_host.hostname:
+            session_id_from_host_path = _runtime_session_id_from_path(parsed_host.path)
+            if session_id_from_host_path:
+                return f"{session_id_from_host_path}.{parsed_host.hostname}"
+            return parsed_host.hostname
+        return runtime_host
+
+    return base_url.hostname or ""
+
+
 def _build_sandbox_exposed_url(runtime, port: int) -> str:
     parsed = urlsplit(runtime.base_url)
-    hostname = parsed.hostname
-    if not hostname:
+    session_host = _resolve_sandbox_runtime_session_host(runtime, parsed)
+    if not session_host:
         return runtime.base_url
 
-    exposed_host = f"{port}-{hostname}"
+    exposed_host = f"{port}-{session_host}"
     netloc = exposed_host
     if parsed.port:
         netloc = f"{netloc}:{parsed.port}"
@@ -100,9 +127,7 @@ def _build_sandbox_exposed_url(runtime, port: int) -> str:
             credentials = f"{credentials}:{parsed.password}"
         netloc = f"{credentials}@{netloc}"
 
-    path = parsed.path or "/"
-
-    return urlunsplit((parsed.scheme, netloc, path, parsed.query, parsed.fragment))
+    return urlunsplit((parsed.scheme, netloc, "/", "", ""))
 
 
 def _expires_within_buffer(expires_at: Optional[datetime]) -> bool:

--- a/hyperbrowser/client/managers/sandboxes/shared.py
+++ b/hyperbrowser/client/managers/sandboxes/shared.py
@@ -17,6 +17,7 @@ from ....sandbox_common import (
     RUNTIME_SESSION_REFRESH_BUFFER_MS,
     normalize_network_error,
     parse_error_payload,
+    runtime_base_url_session_id,
 )
 
 DEFAULT_WATCH_TIMEOUT_MS = 60_000
@@ -84,17 +85,8 @@ def _normalize_exec_params(
     return _normalize_legacy_process_fields(normalized)
 
 
-def _runtime_session_id_from_path(raw_path: str) -> Optional[str]:
-    segments = [
-        segment for segment in raw_path.strip().strip("/").split("/") if segment
-    ]
-    if len(segments) < 2 or segments[0] != "sandbox" or not segments[1]:
-        return None
-    return segments[1]
-
-
 def _resolve_sandbox_runtime_session_host(runtime, base_url) -> str:
-    session_id_from_base_path = _runtime_session_id_from_path(base_url.path)
+    session_id_from_base_path = runtime_base_url_session_id(base_url.path)
     if session_id_from_base_path and base_url.hostname:
         return f"{session_id_from_base_path}.{base_url.hostname}"
 
@@ -102,7 +94,7 @@ def _resolve_sandbox_runtime_session_host(runtime, base_url) -> str:
     if runtime_host:
         parsed_host = urlsplit(runtime_host)
         if parsed_host.hostname:
-            session_id_from_host_path = _runtime_session_id_from_path(parsed_host.path)
+            session_id_from_host_path = runtime_base_url_session_id(parsed_host.path)
             if session_id_from_host_path:
                 return f"{session_id_from_host_path}.{parsed_host.hostname}"
             return parsed_host.hostname

--- a/hyperbrowser/sandbox_common.py
+++ b/hyperbrowser/sandbox_common.py
@@ -114,13 +114,61 @@ def has_scheme(value: str) -> bool:
     return "://" in value
 
 
+def runtime_base_url_session_id(runtime_base_url: str) -> Optional[str]:
+    parsed_base_url = urlsplit(runtime_base_url.strip())
+    segments = [
+        segment
+        for segment in parsed_base_url.path.strip().strip("/").split("/")
+        if segment
+    ]
+    if len(segments) < 2 or segments[0] != "sandbox" or not segments[1].strip():
+        return None
+    return segments[1].strip()
+
+
+def should_prepend_sandbox_to_runtime_api(runtime_base_url: str) -> bool:
+    return runtime_base_url_session_id(runtime_base_url) is None
+
+
+def normalize_runtime_api_path(pathname: str, prepend_sandbox: bool) -> str:
+    trimmed = pathname.strip()
+    if trimmed == "":
+        return "/sandbox" if prepend_sandbox else "/"
+
+    absolute = trimmed if trimmed.startswith("/") else f"/{trimmed}"
+    if prepend_sandbox:
+        if absolute == "/sandbox" or absolute.startswith("/sandbox/"):
+            return absolute
+        return f"/sandbox{absolute}"
+
+    if absolute == "/sandbox":
+        return "/"
+    if absolute.startswith("/sandbox/"):
+        return f"/{absolute[len('/sandbox/'):]}"
+    return absolute
+
+
+def normalize_runtime_relative_path(base_url: str, path: str) -> str:
+    trimmed = path.strip()
+    if trimmed == "":
+        return ""
+
+    parsed_path = urlsplit(trimmed)
+    prepend_sandbox = should_prepend_sandbox_to_runtime_api(base_url)
+    normalized_path = normalize_runtime_api_path(parsed_path.path, prepend_sandbox)
+    relative_path = normalized_path.lstrip("/")
+    return urlunsplit(
+        ("", "", relative_path, parsed_path.query, parsed_path.fragment)
+    )
+
+
 def resolve_runtime_transport_target(
     base_url: str,
     path: str,
     runtime_proxy_override: Optional[str] = None,
 ) -> RuntimeTransportTarget:
     normalized_base = base_url if base_url.endswith("/") else f"{base_url}/"
-    url = urljoin(normalized_base, path.lstrip("/"))
+    url = urljoin(normalized_base, normalize_runtime_relative_path(base_url, path))
 
     if not runtime_proxy_override:
         return RuntimeTransportTarget(url=url)
@@ -151,7 +199,7 @@ def to_websocket_transport_target(
     runtime_proxy_override: Optional[str] = None,
 ) -> RuntimeTransportTarget:
     normalized_base = base_url if base_url.endswith("/") else f"{base_url}/"
-    url = urljoin(normalized_base, path.lstrip("/"))
+    url = urljoin(normalized_base, normalize_runtime_relative_path(base_url, path))
     parts = urlsplit(url)
     scheme = parts.scheme
     if scheme == "https":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.90.2"
+version = "0.90.3"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"

--- a/tests/sandbox/e2e/test_async_expose.py
+++ b/tests/sandbox/e2e/test_async_expose.py
@@ -1,4 +1,5 @@
 import asyncio
+from urllib.parse import urlparse
 
 import pytest
 
@@ -99,6 +100,8 @@ async def test_async_sandbox_expose_e2e():
         assert exposure.port == HTTP_PORT
         assert exposure.auth is False
         assert exposure.url == sandbox.get_exposed_url(HTTP_PORT)
+        if "/sandbox/" in sandbox.runtime.base_url:
+            assert urlparse(exposure.url).hostname.startswith(f"{HTTP_PORT}-{sandbox.id}.")
 
         status, body = await _wait_for_http_response(
             exposure.url,

--- a/tests/sandbox/e2e/test_expose.py
+++ b/tests/sandbox/e2e/test_expose.py
@@ -1,4 +1,5 @@
 import time
+from urllib.parse import urlparse
 
 from hyperbrowser.models import SandboxExecParams, SandboxExposeParams
 
@@ -92,6 +93,8 @@ def test_sandbox_expose_e2e():
         assert exposure.port == HTTP_PORT
         assert exposure.auth is False
         assert exposure.url == sandbox.get_exposed_url(HTTP_PORT)
+        if "/sandbox/" in sandbox.runtime.base_url:
+            assert urlparse(exposure.url).hostname.startswith(f"{HTTP_PORT}-{sandbox.id}.")
 
         status, body = _wait_for_http_response(
             exposure.url,

--- a/tests/sandbox/e2e/test_runtime_transport.py
+++ b/tests/sandbox/e2e/test_runtime_transport.py
@@ -18,6 +18,16 @@ def test_runtime_transport_target_ignores_ambient_proxy_without_explicit_overrid
     assert target.host_header is None
 
 
+def test_runtime_transport_target_prepends_sandbox_for_session_host_relative_paths():
+    target = resolve_runtime_transport_target(
+        "https://session.example.dev:8443",
+        "/exec?foo=bar",
+    )
+
+    assert target.url == "https://session.example.dev:8443/sandbox/exec?foo=bar"
+    assert target.host_header is None
+
+
 def test_runtime_transport_target_applies_explicit_proxy_override():
     target = resolve_runtime_transport_target(
         "https://session.example.dev:8443",
@@ -27,6 +37,26 @@ def test_runtime_transport_target_applies_explicit_proxy_override():
 
     assert target.url == "http://127.0.0.1:8090/sandbox/exec?foo=bar"
     assert target.host_header == "session.example.dev:8443"
+
+
+def test_runtime_transport_target_preserves_region_path_base_prefix():
+    target = resolve_runtime_transport_target(
+        "https://region.example.dev/sandbox/sbx_123",
+        "/sandbox/exec?foo=bar",
+    )
+
+    assert target.url == "https://region.example.dev/sandbox/sbx_123/exec?foo=bar"
+    assert target.host_header is None
+
+
+def test_runtime_transport_target_avoids_double_sandbox_for_region_path_base():
+    target = resolve_runtime_transport_target(
+        "https://region.example.dev/sandbox/sbx_123",
+        "/exec?foo=bar",
+    )
+
+    assert target.url == "https://region.example.dev/sandbox/sbx_123/exec?foo=bar"
+    assert target.host_header is None
 
 
 def test_runtime_websocket_target_applies_explicit_proxy_override():
@@ -39,6 +69,21 @@ def test_runtime_websocket_target_applies_explicit_proxy_override():
     assert (
         target.url
         == "wss://session.example.dev:8443/sandbox/pty/pty_123/ws?sessionId=sandbox_123"
+    )
+    assert target.connect_host == "127.0.0.1"
+    assert target.connect_port == 8090
+
+
+def test_runtime_websocket_target_preserves_region_path_base_prefix():
+    target = to_websocket_transport_target(
+        "https://region.example.dev/sandbox/sbx_123",
+        "/sandbox/pty/pty_123/ws?sessionId=sandbox_123",
+        "http://127.0.0.1:8090",
+    )
+
+    assert (
+        target.url
+        == "wss://region.example.dev/sandbox/sbx_123/pty/pty_123/ws?sessionId=sandbox_123"
     )
     assert target.connect_host == "127.0.0.1"
     assert target.connect_port == 8090

--- a/tests/test_sandbox_wire_contract.py
+++ b/tests/test_sandbox_wire_contract.py
@@ -1,5 +1,6 @@
 import httpx
 import pytest
+from types import SimpleNamespace
 import hyperbrowser.client.managers.async_manager.sandboxes.sandbox_terminal as async_terminal_module
 import hyperbrowser.client.managers.sync_manager.sandboxes.sandbox_terminal as sync_terminal_module
 
@@ -25,6 +26,7 @@ from hyperbrowser.client.managers.sync_manager.sandboxes.sandbox_processes impor
 from hyperbrowser.client.managers.sync_manager.sandboxes.sandbox_terminal import (
     SandboxTerminalApi,
 )
+from hyperbrowser.client.managers.sandboxes.shared import _build_sandbox_exposed_url
 from hyperbrowser.models import (
     CreateSandboxParams,
     SandboxDetail,
@@ -70,15 +72,15 @@ SANDBOX_DETAIL_PAYLOAD = {
     "diskSizeMiB": 8192,
     "runtime": {
         "transport": "regional_proxy",
-        "host": "runtime.example.com",
-        "baseUrl": "https://runtime.example.com",
+        "host": "https://runtime.example.com",
+        "baseUrl": "https://runtime.example.com/sandbox/sbx_123",
     },
     "exposedPorts": [
         {
             "port": 3000,
             "auth": True,
-            "url": "https://3000-runtime.example.com/",
-            "browserUrl": "https://3000-runtime.example.com/_hb/auth?grant=test&next=%2F",
+            "url": "https://3000-sbx_123.runtime.example.com/",
+            "browserUrl": "https://3000-sbx_123.runtime.example.com/_hb/auth?grant=test&next=%2F",
             "browserUrlExpiresAt": "2026-03-12T02:00:00Z",
         }
     ],
@@ -122,15 +124,15 @@ SANDBOX_LIST_PAYLOAD = {
             "diskSizeMiB": 8192,
             "runtime": {
                 "transport": "regional_proxy",
-                "host": "runtime.example.com",
-                "baseUrl": "https://runtime.example.com",
+                "host": "https://runtime.example.com",
+                "baseUrl": "https://runtime.example.com/sandbox/sbx_123",
             },
             "exposedPorts": [
                 {
                     "port": 3000,
                     "auth": False,
-                    "url": "https://3000-runtime.example.com/",
-                    "browserUrl": "https://3000-runtime.example.com/",
+                    "url": "https://3000-sbx_123.runtime.example.com/",
+                    "browserUrl": "https://3000-sbx_123.runtime.example.com/",
                 }
             ],
         }
@@ -296,8 +298,8 @@ WRITE_FILE_PAYLOAD = {
 EXPOSE_PAYLOAD = {
     "port": 3000,
     "auth": True,
-    "url": "https://3000-runtime.example.com/",
-    "browserUrl": "https://3000-runtime.example.com/_hb/auth?grant=test&next=%2F",
+    "url": "https://3000-sbx_123.runtime.example.com/",
+    "browserUrl": "https://3000-sbx_123.runtime.example.com/_hb/auth?grant=test&next=%2F",
     "browserUrlExpiresAt": "2026-03-12T02:00:00Z",
 }
 
@@ -719,6 +721,7 @@ def test_sync_sandbox_control_manager_uses_expected_wire_keys():
     assert sandbox.memory_mib == 2048
     assert sandbox.disk_mib == 8192
     assert sandbox.exposed_ports[0].browser_url is not None
+    assert sandbox.get_exposed_url(3000) == "https://3000-sbx_123.runtime.example.com/"
     assert expose_call["json"] == {"port": 3000, "auth": True}
     assert exposed.browser_url is not None
     assert expose_call["url"].endswith("/sandbox/sbx_123/expose")
@@ -731,6 +734,30 @@ def test_snapshot_summary_allows_missing_compatibility_tag():
     snapshot = SandboxSnapshotSummary(**SNAPSHOT_PAYLOAD_WITHOUT_COMPATIBILITY_TAG)
 
     assert snapshot.compatibility_tag is None
+
+
+def test_build_sandbox_exposed_url_uses_runtime_base_path_session_id():
+    runtime = SimpleNamespace(
+        host="https://runtime.example.com",
+        base_url="https://runtime.example.com/sandbox/sbx_123",
+    )
+
+    assert (
+        _build_sandbox_exposed_url(runtime, 3000)
+        == "https://3000-sbx_123.runtime.example.com/"
+    )
+
+
+def test_build_sandbox_exposed_url_uses_session_id_from_runtime_host_path():
+    runtime = SimpleNamespace(
+        host="https://runtime.example.com/sandbox/sbx_123",
+        base_url="https://runtime.example.com",
+    )
+
+    assert (
+        _build_sandbox_exposed_url(runtime, 3000)
+        == "https://3000-sbx_123.runtime.example.com/"
+    )
 
 
 def test_sync_sandbox_runtime_apis_use_expected_wire_keys():
@@ -1017,6 +1044,7 @@ async def test_async_sandbox_control_manager_uses_expected_wire_keys():
     assert sandbox.memory_mib == 2048
     assert sandbox.disk_mib == 8192
     assert sandbox.exposed_ports[0].browser_url is not None
+    assert sandbox.get_exposed_url(3000) == "https://3000-sbx_123.runtime.example.com/"
     assert expose_call["json"] == {"port": 3000, "auth": True}
     assert exposed.browser_url is not None
     assert isinstance(unexposed, SandboxUnexposeResult)


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperbrowserai/python-sdk/pull/73" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts how runtime API and exposed-port URLs are constructed, which can affect connectivity for existing sandbox sessions if path/host parsing is wrong. Changes are covered by updated unit and e2e assertions but still touch core routing logic.
> 
> **Overview**
> Fixes sandbox runtime URL construction to correctly handle *regional* runtime `baseUrl`s that already include `/sandbox/{sessionId}` and to avoid double-/missing-`/sandbox` prefixes when joining relative paths.
> 
> Exposed port URLs now incorporate the sandbox session id into the hostname (e.g. `https://3000-sbx_123.runtime.example.com/`) by extracting the id from `runtime.base_url` (or `runtime.host` fallback) and always emitting a root-path exposed URL.
> 
> Updates wire-contract/e2e tests to assert the new URL shapes and adds targeted tests for the new parsing helpers; bumps version to `0.90.3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc8e0e22ebb9fd0e55cc825ac22d9dbae0a50b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->