### PR TITLE
add opus 4.7 for claude computer use

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -63,6 +63,7 @@ HyperAgentLlm = Literal[
 ClaudeComputerUseLlm = Literal[
     "claude-opus-4-5",
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-haiku-4-5-20251001",
     "claude-sonnet-4-6",
     "claude-sonnet-4-5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.90.3"
+version = "0.90.4"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperbrowserai/python-sdk/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change limited to model-name constants and a version bump; minimal behavioral impact beyond enabling a new identifier.
> 
> **Overview**
> Adds support for the `claude-opus-4-7` model by extending the `ClaudeComputerUseLlm` literal in `hyperbrowser/models/consts.py`.
> 
> Bumps the package version in `pyproject.toml` from `0.90.3` to `0.90.4` to publish the updated model list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64f8705cba1007aa906036e7afbb9df0bdedc53d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->