### PR TITLE
add gpt-5.5

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -46,6 +46,7 @@ BrowserUseLlm = Literal[
     "gemini-2.5-flash",
 ]
 HyperAgentLlm = Literal[
+    "gpt-5.5",
     "gpt-5.2",
     "gpt-5.1",
     "gpt-5",
@@ -70,7 +71,7 @@ ClaudeComputerUseLlm = Literal[
     "claude-sonnet-4-20250514",
     "claude-3-7-sonnet-20250219",
 ]
-CuaLlm = Literal["computer-use-preview", "gpt-5.4", "gpt-5.4-mini"]
+CuaLlm = Literal["computer-use-preview", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"]
 GeminiComputerUseLlm = Literal[
     "gemini-3-flash-preview",
     "gemini-2.5-computer-use-preview-10-2025",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.90.5"
+version = "0.90.6"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperbrowserai/python-sdk/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands allowed `Literal` model names and bumps the package version, with no behavioral logic changes. Risk is limited to potential downstream validation/compat expectations around the newly accepted model string.
> 
> **Overview**
> Adds `gpt-5.5` as an accepted model identifier for `HyperAgentLlm` and `CuaLlm` in `hyperbrowser/models/consts.py`, enabling those agents to request the new model without type/validation errors.
> 
> Bumps the SDK version in `pyproject.toml` from `0.90.5` to `0.90.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ad6fd0133b19db5907cecae5b18ed6be36c20b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->