### PR TITLE
add update screen size functionality

### DIFF
--- a/hyperbrowser/client/managers/async_manager/session.py
+++ b/hyperbrowser/client/managers/async_manager/session.py
@@ -16,6 +16,7 @@ from ....models.session import (
     SessionEventLog,
     UpdateSessionProfileParams,
     UpdateSessionProxyParams,
+    UpdateSessionScreenParams,
     SessionGetParams,
 )
 
@@ -193,6 +194,20 @@ class SessionManager:
             self._client._build_url(f"/session/{id}/update"),
             data={
                 "type": "proxy",
+                "params": params.model_dump(exclude_none=True, by_alias=True),
+            },
+        )
+        return BasicResponse(**response.data)
+
+    async def update_screen_size(
+        self,
+        id: str,
+        params: UpdateSessionScreenParams,
+    ) -> BasicResponse:
+        response = await self._client.transport.put(
+            self._client._build_url(f"/session/{id}/update"),
+            data={
+                "type": "screen",
                 "params": params.model_dump(exclude_none=True, by_alias=True),
             },
         )

--- a/hyperbrowser/client/managers/sync_manager/session.py
+++ b/hyperbrowser/client/managers/sync_manager/session.py
@@ -15,6 +15,7 @@ from ....models.session import (
     SessionEventLogListResponse,
     UpdateSessionProfileParams,
     UpdateSessionProxyParams,
+    UpdateSessionScreenParams,
     SessionGetParams,
 )
 
@@ -188,6 +189,20 @@ class SessionManager:
             self._client._build_url(f"/session/{id}/update"),
             data={
                 "type": "proxy",
+                "params": params.model_dump(exclude_none=True, by_alias=True),
+            },
+        )
+        return BasicResponse(**response.data)
+
+    def update_screen_size(
+        self,
+        id: str,
+        params: UpdateSessionScreenParams,
+    ) -> BasicResponse:
+        response = self._client.transport.put(
+            self._client._build_url(f"/session/{id}/update"),
+            data={
+                "type": "screen",
                 "params": params.model_dump(exclude_none=True, by_alias=True),
             },
         )

--- a/hyperbrowser/models/__init__.py
+++ b/hyperbrowser/models/__init__.py
@@ -262,6 +262,7 @@ from .session import (
     UpdateSessionProfileParams,
     UpdateSessionProxyLocationParams,
     UpdateSessionProxyParams,
+    UpdateSessionScreenParams,
 )
 from .sandbox import (
     SandboxStatus,
@@ -523,6 +524,7 @@ __all__ = [
     "UpdateSessionProfileParams",
     "UpdateSessionProxyLocationParams",
     "UpdateSessionProxyParams",
+    "UpdateSessionScreenParams",
     # sandbox
     "SandboxStatus",
     "SandboxRegion",

--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -100,6 +100,19 @@ class UpdateSessionProxyParams(BaseModel):
     )
 
 
+class UpdateSessionScreenParams(BaseModel):
+    """
+    Parameters for updating the screen size of a running session.
+    """
+
+    model_config = ConfigDict(
+        populate_by_alias=True,
+    )
+
+    width: int = Field(serialization_alias="width")
+    height: int = Field(serialization_alias="height")
+
+
 class SessionLaunchState(BaseModel):
     model_config = ConfigDict(
         populate_by_alias=True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.90.6"
+version = "0.90.7"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk SDK surface-area addition that reuses the existing `/session/{id}/update` endpoint; main risk is minor client compatibility/typing issues for the new params model.
> 
> **Overview**
> Adds support for resizing a running session via the SDK.
> 
> Both sync and async `SessionManager` gain `update_screen_size(id, params)` which sends a `/session/{id}/update` request with `type: "screen"` and `width`/`height` parameters, backed by a new `UpdateSessionScreenParams` model exported from `hyperbrowser.models`.
> 
> Bumps package version to `0.90.7`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed68d0ee00b35bd5e43a0cf5aaf333b4c379093e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->