### PR TITLE
add list_windows computer action

### DIFF
--- a/hyperbrowser/client/managers/async_manager/computer_action.py
+++ b/hyperbrowser/client/managers/async_manager/computer_action.py
@@ -18,6 +18,7 @@ from hyperbrowser.models import (
     ComputerActionMouseButton,
     GetClipboardTextActionParams,
     PutSelectionTextActionParams,
+    ListWindowsActionParams,
 )
 
 
@@ -174,4 +175,12 @@ class ComputerActionManager:
         params = PutSelectionTextActionParams(
             text=text, return_screenshot=return_screenshot
         )
+        return await self._execute_request(session, params)
+
+    async def list_windows(
+        self,
+        session: Union[SessionDetail, str],
+        return_screenshot: bool = False,
+    ) -> ComputerActionResponse:
+        params = ListWindowsActionParams(return_screenshot=return_screenshot)
         return await self._execute_request(session, params)

--- a/hyperbrowser/client/managers/sync_manager/computer_action.py
+++ b/hyperbrowser/client/managers/sync_manager/computer_action.py
@@ -18,6 +18,7 @@ from hyperbrowser.models import (
     ComputerActionMouseButton,
     GetClipboardTextActionParams,
     PutSelectionTextActionParams,
+    ListWindowsActionParams,
 )
 
 
@@ -174,4 +175,12 @@ class ComputerActionManager:
         params = PutSelectionTextActionParams(
             text=text, return_screenshot=return_screenshot
         )
+        return self._execute_request(session, params)
+
+    def list_windows(
+        self,
+        session: Union[SessionDetail, str],
+        return_screenshot: bool = False,
+    ) -> ComputerActionResponse:
+        params = ListWindowsActionParams(return_screenshot=return_screenshot)
         return self._execute_request(session, params)

--- a/hyperbrowser/models/__init__.py
+++ b/hyperbrowser/models/__init__.py
@@ -233,7 +233,10 @@ from .computer_action import (
     ComputerActionMouseButton,
     GetClipboardTextActionParams,
     PutSelectionTextActionParams,
+    ListWindowsActionParams,
+    ComputerActionWindow,
     ComputerActionResponseDataClipboardText,
+    ComputerActionResponseDataListWindows,
     ComputerActionResponseData,
 )
 from .session import (
@@ -628,7 +631,10 @@ __all__ = [
     "ComputerActionMouseButton",
     "GetClipboardTextActionParams",
     "PutSelectionTextActionParams",
+    "ListWindowsActionParams",
+    "ComputerActionWindow",
     "ComputerActionResponseDataClipboardText",
+    "ComputerActionResponseDataListWindows",
     "ComputerActionResponseData",
     # web
     "StartBatchFetchJobParams",

--- a/hyperbrowser/models/computer_action.py
+++ b/hyperbrowser/models/computer_action.py
@@ -18,6 +18,7 @@ class ComputerAction(str, Enum):
     TYPE_TEXT = "type_text"
     GET_CLIPBOARD_TEXT = "get_clipboard_text"
     PUT_SELECTION_TEXT = "put_selection_text"
+    LIST_WINDOWS = "list_windows"
 
 
 ComputerActionMouseButton = Literal[
@@ -183,6 +184,17 @@ class PutSelectionTextActionParams(BaseModel):
     )
 
 
+class ListWindowsActionParams(BaseModel):
+    """Parameters for list windows action."""
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    action: Literal[ComputerAction.LIST_WINDOWS] = ComputerAction.LIST_WINDOWS
+    return_screenshot: bool = Field(
+        serialization_alias="returnScreenshot", default=False
+    )
+
+
 ComputerActionParams = Union[
     ClickActionParams,
     DragActionParams,
@@ -196,6 +208,7 @@ ComputerActionParams = Union[
     MouseUpActionParams,
     GetClipboardTextActionParams,
     PutSelectionTextActionParams,
+    ListWindowsActionParams,
 ]
 
 
@@ -207,7 +220,27 @@ class ComputerActionResponseDataClipboardText(BaseModel):
     clipboard_text: Optional[str] = Field(default=None, alias="clipboardText")
 
 
-ComputerActionResponseData = Union[ComputerActionResponseDataClipboardText]
+class ComputerActionWindow(BaseModel):
+    model_config = ConfigDict(populate_by_alias=True)
+
+    id: str
+    name: str
+    active: bool
+
+
+class ComputerActionResponseDataListWindows(BaseModel):
+    """Data for list windows action."""
+
+    model_config = ConfigDict(populate_by_alias=True)
+
+    active_window_id: str = Field(default="", alias="activeWindowId")
+    windows: List[ComputerActionWindow] = Field(default_factory=list)
+
+
+ComputerActionResponseData = Union[
+    ComputerActionResponseDataListWindows,
+    ComputerActionResponseDataClipboardText,
+]
 
 
 class ComputerActionResponse(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.90.7"
+version = "0.90.8"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new computer-action API call and expands `ComputerActionResponse.data` to a broader union, which could affect downstream parsing/typing for users who assumed only clipboard-text data.
> 
> **Overview**
> Adds a new `list_windows` computer action to both async and sync `ComputerActionManager`, sending `ListWindowsActionParams` with optional `return_screenshot`.
> 
> Extends computer-action models with the `LIST_WINDOWS` enum value, request params, and response types (`ComputerActionWindow` and `ComputerActionResponseDataListWindows`), and re-exports them via `hyperbrowser.models`. Bumps the SDK version to `0.90.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbe39f0e700893a032234f93dc239d71a9471b17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->