### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,20 @@
 ## Configuration & Secrets
 - Set `HYPERBROWSER_API_KEY` via environment variables or pass `api_key=` in client constructors.
 - Never commit API keys or session data; use `.env` or local shell exports for development.
+
+## Cursor Cloud specific instructions
+
+### Dev commands
+
+- `poetry install` — install all dependencies
+- `poetry run ruff check .` — lint (pre-existing warnings are expected in the
+  current codebase)
+- `poetry run ruff format .` — auto-format
+- `poetry run pytest` — run tests (pytest is a dev dependency)
+
+### Gotchas
+
+- Poetry must be on `PATH`. The Cloud Agent VM installs it via
+  `pip3 install poetry`; the binary lands in `~/.local/bin`.
+- The baseline codebase has ~10 pre-existing ruff lint warnings (unused imports,
+  bare `except`). These are not regressions.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor Cloud specific development instructions to `AGENTS.md`, including:

- Dev command reference (`poetry install`, `ruff check`, `ruff format`, `pytest`)
- Gotcha: Poetry binary path (`~/.local/bin`) must be on `PATH`
- Gotcha: ~10 pre-existing ruff lint warnings in the codebase are expected, not regressions
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdb0a08a-00a7-41cc-9dee-15630a72c6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdb0a08a-00a7-41cc-9dee-15630a72c6fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

