### PR TITLE
Update integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,6 +1,8 @@
 name: Integration Tests
 
 on:
+  pull_request:
+    branches: [main]
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -24,7 +26,7 @@ jobs:
 
       - name: Check out repository
         if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python
         if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,27 +14,42 @@ permissions:
 
 jobs:
   integration-tests:
-    runs-on: depot-ubuntu-24.04-16
+    name: integration-tests
+    runs-on: ubuntu-24.04
 
     steps:
+      - name: PR placeholder
+        if: github.event_name == 'pull_request'
+        run: echo "Integration tests run only in the merge queue."
+
       - name: Check out repository
-        uses: actions/checkout@v6
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v5
 
       - name: Set up Python
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install Poetry
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: python -m pip install --upgrade pip poetry
 
       - name: Show tool versions
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: |
           python --version
           poetry --version
 
       - name: Install dependencies
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: poetry install --with dev --no-interaction
 
+      - name: Build package
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+        run: poetry build
+
       - name: Run integration tests
+        if: github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
         run: poetry run pytest tests/integration


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is CI behavior, potentially skipping integration coverage on PRs if merge queue isn’t used as expected.
> 
> **Overview**
> Integration test workflow is updated to trigger on `pull_request` but only emit a placeholder message, while the real integration test job runs only for `merge_group` (merge queue) and `workflow_dispatch` events.
> 
> The job now runs on `ubuntu-24.04` (instead of the custom runner) and adds a `poetry build` step before executing `pytest` integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 812fa0267a72b09f5584857bbefa8837839e3850. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->