### PR TITLE
feat: add Claude Opus 4.8 to ClaudeComputerUseLlm type

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -65,6 +65,7 @@ ClaudeComputerUseLlm = Literal[
     "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-opus-4-8",
     "claude-haiku-4-5-20251001",
     "claude-sonnet-4-6",
     "claude-sonnet-4-5",


### PR DESCRIPTION
## Summary

Adds `"claude-opus-4-8"` to the `ClaudeComputerUseLlm` Literal type in `hyperbrowser/models/consts.py`.