### PR TITLE
add disabled_external_protocols

### DIFF
--- a/hyperbrowser/client/managers/async_manager/session.py
+++ b/hyperbrowser/client/managers/async_manager/session.py
@@ -264,7 +264,6 @@ class SessionManager:
         )
         return UpdateSessionSolveCaptchasResponse(**response.data)
 
-
     def _warn_update_profile_params_boolean_deprecated(self) -> None:
         if SessionManager._has_warned_update_profile_params_boolean_deprecated:
             return

--- a/hyperbrowser/client/managers/sync_manager/profile.py
+++ b/hyperbrowser/client/managers/sync_manager/profile.py
@@ -24,9 +24,7 @@ class ProfileManager:
         )
         return CreateProfileResponse(**response.data)
 
-    def fork(
-        self, id: str, params: ForkProfileParams = None
-    ) -> CreateProfileResponse:
+    def fork(self, id: str, params: ForkProfileParams = None) -> CreateProfileResponse:
         response = self._client.transport.post(
             self._client._build_url(f"/profile/{id}/fork"),
             data=(

--- a/hyperbrowser/client/managers/sync_manager/session.py
+++ b/hyperbrowser/client/managers/sync_manager/session.py
@@ -259,7 +259,6 @@ class SessionManager:
         )
         return UpdateSessionSolveCaptchasResponse(**response.data)
 
-
     def _warn_update_profile_params_boolean_deprecated(self) -> None:
         if SessionManager._has_warned_update_profile_params_boolean_deprecated:
             return

--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -446,6 +446,9 @@ class CreateSessionParams(BaseModel):
     browser_args: Optional[List[str]] = Field(
         default=None, serialization_alias="browserArgs"
     )
+    disabled_external_protocols: Optional[List[str]] = Field(
+        default=None, serialization_alias="disabledExternalProtocols"
+    )
     save_downloads: Optional[bool] = Field(
         default=None, serialization_alias="saveDownloads"
     )

--- a/hyperbrowser/sandbox_common.py
+++ b/hyperbrowser/sandbox_common.py
@@ -157,9 +157,7 @@ def normalize_runtime_relative_path(base_url: str, path: str) -> str:
     prepend_sandbox = should_prepend_sandbox_to_runtime_api(base_url)
     normalized_path = normalize_runtime_api_path(parsed_path.path, prepend_sandbox)
     relative_path = normalized_path.lstrip("/")
-    return urlunsplit(
-        ("", "", relative_path, parsed_path.query, parsed_path.fragment)
-    )
+    return urlunsplit(("", "", relative_path, parsed_path.query, parsed_path.fragment))
 
 
 def resolve_runtime_transport_target(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.91.2"
+version = "0.91.3"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Additive optional model field and patch version bump; no changes to request routing or auth logic.
> 
> **Overview**
> Adds **`disabled_external_protocols`** to **`CreateSessionParams`** so callers can pass a list of external protocol handlers to disable when creating a session (serialized as `disabledExternalProtocols` on the API). Session create flows pick this up automatically via existing `model_dump` behavior.
> 
> Bumps the package version to **0.91.3**. Includes minor formatting-only edits (whitespace and line wrapping) in session managers, profile `fork`, and `normalize_runtime_relative_path`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed1cb0d81f745ad83acf28d16f91822d45cb75c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->