### PR TITLE
add livedomain

### DIFF
--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -243,6 +243,7 @@ class SessionDetail(Session):
     )
     webdriver_endpoint: Optional[str] = Field(alias="webdriverEndpoint", default=None)
     live_url: str = Field(alias="liveUrl")
+    live_domain: Optional[str] = Field(alias="liveDomain", default=None)
     token: str = Field(alias="token")
 
 
@@ -486,6 +487,7 @@ class CreateSessionParams(BaseModel):
     live_view_ttl_seconds: Optional[int] = Field(
         default=None, serialization_alias="liveViewTtlSeconds"
     )
+    live_domain: Optional[str] = Field(default=None, serialization_alias="liveDomain")
     replace_native_elements: Optional[bool] = Field(
         default=None,
         serialization_alias="replaceNativeElements",

--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -487,7 +487,6 @@ class CreateSessionParams(BaseModel):
     live_view_ttl_seconds: Optional[int] = Field(
         default=None, serialization_alias="liveViewTtlSeconds"
     )
-    live_domain: Optional[str] = Field(default=None, serialization_alias="liveDomain")
     replace_native_elements: Optional[bool] = Field(
         default=None,
         serialization_alias="replaceNativeElements",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.91.3"
+version = "0.91.4"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed and why. -->

## Changes
<!-- Bullet list of the concrete changes. Keep it short. -->
- 
- 

## Validation
<!-- Commands you ran. Mention any manual testing. -->
- `ruff check`
- `pytest`

<!-- Closes #123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional Pydantic field with no logic changes; backward compatible for existing callers.
> 
> **Overview**
> Adds optional **`live_domain`** on **`SessionDetail`**, deserialized from the API’s **`liveDomain`** field alongside existing live-view fields like **`live_url`**.
> 
> Bumps the package version to **0.91.4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6089400a00b96d4da858a9bd742fe75fdb252f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->