### PR TITLE
[codex] Add active session profile fork parameter

### DIFF
--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -77,6 +77,10 @@ class UpdateSessionProfileParams(BaseModel):
         default=None,
         serialization_alias="persistNetworkCache",
     )
+    fork_to_profile_id: Optional[str] = Field(
+        default=None,
+        serialization_alias="forkToProfileId",
+    )
 
 
 class UpdateSessionProxyLocationParams(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.92.0"
+version = "0.92.1"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Adds `fork_to_profile_id`, serialized as `forkToProfileId`, to `UpdateSessionProfileParams`.
- Bumps the Python SDK version from `0.92.0` to `0.92.1`.

## Validation

- `poetry run ruff check hyperbrowser/models/session.py`
- `poetry run python -m compileall hyperbrowser/models/session.py`
- `poetry check` (passes with existing project metadata deprecation warnings)

Created via Codex after rebasing onto current `origin/main`.