### PR TITLE
add gemini-3.5-flash to gemini computer use

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -74,6 +74,7 @@ ClaudeComputerUseLlm = Literal[
 ]
 CuaLlm = Literal["computer-use-preview", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"]
 GeminiComputerUseLlm = Literal[
+    "gemini-3.5-flash",
     "gemini-3-flash-preview",
     "gemini-2.5-computer-use-preview-10-2025",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.92.0"
+version = "0.92.1"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed and why. -->

## Changes
<!-- Bullet list of the concrete changes. Keep it short. -->
- 
- 

## Validation
<!-- Commands you ran. Mention any manual testing. -->
- `ruff check`
- `pytest`

<!-- Closes #123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive Literal member and patch version bump only; no runtime logic changes.
> 
> **Overview**
> Adds **`gemini-3.5-flash`** to the `GeminiComputerUseLlm` type alias in `consts.py`, so callers can pass that model when starting Gemini Computer Use tasks (e.g. via `StartGeminiComputerUseTaskParams.llm`).
> 
> Bumps the package version from **0.92.0** to **0.92.1** in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f5087f4c596a781bbaa3a7f5bc785b7d52155be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->