### PR TITLE
add browsery memory size

### DIFF
--- a/hyperbrowser/models/__init__.py
+++ b/hyperbrowser/models/__init__.py
@@ -242,6 +242,7 @@ from .computer_action import (
 )
 from .session import (
     BasicResponse,
+    BrowserMemorySize,
     CreateSessionParams,
     CreateSessionProfile,
     CreateSessionSnapshotResponse,
@@ -515,6 +516,7 @@ __all__ = [
     "StorageStateOptions",
     # session
     "BasicResponse",
+    "BrowserMemorySize",
     "CreateSessionParams",
     "CreateSessionProfile",
     "CreateSessionSnapshotResponse",

--- a/hyperbrowser/models/session.py
+++ b/hyperbrowser/models/session.py
@@ -16,6 +16,7 @@ from hyperbrowser.models.consts import (
 )
 
 SessionStatus = Literal["active", "closed", "error"]
+BrowserMemorySize = Literal["small", "medium", "large"]
 CaptchaSolverType = Literal["visual"]
 CaptchaEvaluationType = Literal[
     "turnstile",
@@ -508,6 +509,9 @@ class CreateSessionParams(BaseModel):
     """
     disable_post_quantum_key_agreement: Optional[bool] = Field(
         default=None, serialization_alias="disablePostQuantumKeyAgreement"
+    )
+    browser_memory_size: Optional[BrowserMemorySize] = Field(
+        default=None, serialization_alias="browserMemorySize"
     )
     start_from_snapshot: Optional[StartSessionFromSnapshotParams] = Field(
         default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.92.1"
+version = "0.92.2"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Optional typed field on session creation models only; no auth or runtime logic changes in this diff.
> 
> **Overview**
> Adds optional **browser memory sizing** when creating browser sessions via `CreateSessionParams`.
> 
> Introduces a `BrowserMemorySize` type (`"small"`, `"medium"`, `"large"`) and an optional `browser_memory_size` field serialized as `browserMemorySize` on the create-session API payload. The type is re-exported from the public `hyperbrowser.models` package. Package version is bumped to **0.92.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92a12807ca2f77627d15ef00f5666bf1d7600c32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->