### PR TITLE
patch the network updat

### DIFF
--- a/hyperbrowser/client/managers/async_manager/sandbox.py
+++ b/hyperbrowser/client/managers/async_manager/sandbox.py
@@ -635,7 +635,11 @@ class SandboxManager:
         payload = await self._request(
             "PUT",
             f"/sandbox/{sandbox_id}/network",
-            data=policy.model_dump(exclude_none=True, by_alias=True),
+            data=policy.model_dump(
+                exclude_none=True,
+                exclude_unset=True,
+                by_alias=True,
+            ),
         )
         return SandboxNetworkUpdateResult(**payload)
 

--- a/hyperbrowser/client/managers/sync_manager/sandbox.py
+++ b/hyperbrowser/client/managers/sync_manager/sandbox.py
@@ -624,7 +624,11 @@ class SandboxManager:
         payload = self._request(
             "PUT",
             f"/sandbox/{sandbox_id}/network",
-            data=policy.model_dump(exclude_none=True, by_alias=True),
+            data=policy.model_dump(
+                exclude_none=True,
+                exclude_unset=True,
+                by_alias=True,
+            ),
         )
         return SandboxNetworkUpdateResult(**payload)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.93.0"
+version = "0.93.1"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"

--- a/tests/test_create_sandbox_params.py
+++ b/tests/test_create_sandbox_params.py
@@ -95,6 +95,28 @@ def test_sandbox_network_policy_serializes_update_payload():
     }
 
 
+def test_sandbox_network_policy_defaults_unset_lists_for_response_models():
+    policy = SandboxNetworkPolicy(allow_internet_access=True)
+
+    assert policy.model_dump(by_alias=True, exclude_none=True) == {
+        "allowInternetAccess": True,
+        "allowOut": [],
+        "denyOut": [],
+    }
+
+
+def test_sandbox_network_policy_can_omit_unset_lists_for_patch_payload():
+    policy = SandboxNetworkPolicy(allow_internet_access=True)
+
+    assert policy.model_dump(
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    ) == {
+        "allowInternetAccess": True,
+    }
+
+
 def test_sandbox_image_build_params_serialize_expected_wire_keys():
     create_params = CreateSandboxImageBuildParams(
         image_name="custom_node",

--- a/tests/test_sandbox_wire_contract.py
+++ b/tests/test_sandbox_wire_contract.py
@@ -699,6 +699,12 @@ def test_sandbox_request_models_serialize_expected_wire_keys():
         "allowOut": [],
         "denyOut": [],
     }
+    assert SandboxNetworkPolicy(allow_internet_access=True).model_dump(
+        by_alias=True, exclude_none=True
+    ) == {"allowInternetAccess": True, "allowOut": [], "denyOut": []}
+    assert SandboxNetworkPolicy(allow_internet_access=True).model_dump(
+        by_alias=True, exclude_none=True, exclude_unset=True
+    ) == {"allowInternetAccess": True}
 
     assert SandboxImageListParams(
         page=2,
@@ -1072,6 +1078,30 @@ def test_sync_sandbox_control_manager_uses_expected_wire_keys():
     assert isinstance(unexposed, SandboxUnexposeResult)
     assert unexpose_call["json"] == {"port": 3000}
     assert unexpose_call["url"].endswith("/sandbox/sbx_123/unexpose")
+
+
+def test_sync_sandbox_update_network_omits_only_unset_lists():
+    client = FakeSyncClient()
+    manager = SandboxManager(client)
+    sandbox = manager.attach(SandboxDetail(**SANDBOX_DETAIL_PAYLOAD))
+
+    sandbox.update_network(SandboxNetworkPolicy(allow_internet_access=True))
+    sandbox.update_network(
+        SandboxNetworkPolicy(
+            allow_internet_access=True,
+            allow_out=[],
+            deny_out=[],
+        )
+    )
+
+    preserve_call = client.transport.client.calls[0]
+    clear_call = client.transport.client.calls[1]
+    assert preserve_call["json"] == {"allowInternetAccess": True}
+    assert clear_call["json"] == {
+        "allowInternetAccess": True,
+        "allowOut": [],
+        "denyOut": [],
+    }
 
 
 def test_snapshot_summary_allows_missing_compatibility_tag():
@@ -1526,6 +1556,31 @@ async def test_async_sandbox_control_manager_uses_expected_wire_keys():
     assert exposed.browser_url is not None
     assert isinstance(unexposed, SandboxUnexposeResult)
     assert unexpose_call["json"] == {"port": 3000}
+
+
+@pytest.mark.anyio
+async def test_async_sandbox_update_network_omits_only_unset_lists():
+    client = FakeAsyncClient()
+    manager = AsyncSandboxManager(client)
+    sandbox = manager.attach(SandboxDetail(**SANDBOX_DETAIL_PAYLOAD))
+
+    await sandbox.update_network(SandboxNetworkPolicy(allow_internet_access=True))
+    await sandbox.update_network(
+        SandboxNetworkPolicy(
+            allow_internet_access=True,
+            allow_out=[],
+            deny_out=[],
+        )
+    )
+
+    preserve_call = client.transport.client.calls[0]
+    clear_call = client.transport.client.calls[1]
+    assert preserve_call["json"] == {"allowInternetAccess": True}
+    assert clear_call["json"] == {
+        "allowInternetAccess": True,
+        "allowOut": [],
+        "denyOut": [],
+    }
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
<!-- 1-2 sentences: what changed and why. -->

## Changes
<!-- Bullet list of the concrete changes. Keep it short. -->
- 
- 

## Validation
<!-- Commands you ran. Mention any manual testing. -->
- `ruff check`
- `pytest`

<!-- Closes #123 -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/hyperbrowserai/python-sdk/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox firewall PUT payloads and could alter server-side merge behavior if the API treated omitted lists differently from empty arrays.
> 
> **Overview**
> Fixes sandbox **network update** requests so partial policies do not always send `allowOut` / `denyOut` as empty arrays.
> 
> Sync and async `SandboxManager.update_network` now serialize `SandboxNetworkPolicy` with `exclude_unset=True` (along with `exclude_none` and aliases). A call that only sets `allowInternetAccess` sends just that field, so existing outbound rules are not cleared unintentionally. Explicit empty lists are still included when the caller sets them (e.g. `clear_network`).
> 
> Bumps the package version to **0.93.1** and adds serialization and wire-contract tests for both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b201e831dffde9acfbdab8cd90c9b818a1296f07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->