### PR TITLE
Add GPT 5.6 agent model support

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -47,6 +47,7 @@ BrowserUseLlm = Literal[
     "gemini-2.5-flash",
 ]
 HyperAgentLlm = Literal[
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.2",
     "gpt-5.1",
@@ -75,7 +76,15 @@ ClaudeComputerUseLlm = Literal[
     "claude-sonnet-4-20250514",
     "claude-3-7-sonnet-20250219",
 ]
-CuaLlm = Literal["computer-use-preview", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"]
+CuaLlm = Literal[
+    "computer-use-preview",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+]
 GeminiComputerUseLlm = Literal[
     "gemini-3.5-flash",
     "gemini-3-flash-preview",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.93.1"
+version = "0.93.2"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Adds Python SDK model literals for the GPT-5.6 models introduced in [browserctrl#1211](https://github.com/hyperbrowserai/browserctrl/pull/1211), while limiting HyperAgent support to Luna.

## Changes
- Add `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` to `CuaLlm`
- Add `gpt-5.6-luna` to `HyperAgentLlm`
- Bump the package version to `0.93.2`

## Validation
- `poetry run ruff check hyperbrowser/models/consts.py`
- `poetry run ruff format --check hyperbrowser/models/consts.py`

Link to Devin session: https://app.devin.ai/sessions/f284337c4bc9449da73ead049ff14a40
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive `Literal` entries and a patch version bump only; no runtime logic changes.
> 
> **Overview**
> Adds Python SDK typing support for new GPT-5.6 models aligned with backend support.
> 
> **`HyperAgentLlm`** now includes **`gpt-5.6-luna`** as the only 5.6 variant for HyperAgent tasks. **`CuaLlm`** adds **`gpt-5.6-sol`**, **`gpt-5.6-terra`**, and **`gpt-5.6-luna`**, and the literal is reformatted to a multi-line list. Package version is bumped to **0.93.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17e5ba3ff2ab50d315289b586584bd31ed93707. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->