### PR TITLE
feat: add py.typed marker for static type checkers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,10 @@ description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"
 readme = "README.md"
-include = ["LICENSE"]
+include = [
+    "LICENSE",
+    { path = "hyperbrowser/py.typed", format = ["sdist", "wheel"] },
+]
 homepage = "https://github.com/hyperbrowserai/python-sdk"
 repository = "https://github.com/hyperbrowserai/python-sdk"
 


### PR DESCRIPTION
## Summary

Add the PEP 561 marker so static type checkers recognize Hyperbrowser's existing inline annotations.

## Changes

- Add an empty `hyperbrowser/py.typed` marker.
- Explicitly include the marker in wheel and source distributions.

## Validation

- `poetry build` (confirmed the marker is present in both the wheel and source distribution)
- `poetry run pytest tests --ignore=tests/sandbox/e2e` (67 passed)
- Clean-wheel strict mypy checks with versions 1.19.1 and 2.3.0 (both passed and resolved `Hyperbrowser` to its annotated constructor signature)
- `poetry run ruff check .` (reports 7 pre-existing F401 errors in unchanged files)

## Compatibility

This is packaging metadata only and does not change runtime behavior or the public API.

Closes #103
