### PR TITLE
feat: add Gemini 3.6 Flash and 3.5 Flash Lite to Gemini CUA

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -86,6 +86,8 @@ CuaLlm = Literal[
     "gpt-5.4-mini",
 ]
 GeminiComputerUseLlm = Literal[
+    "gemini-3.6-flash",
+    "gemini-3.5-flash-lite",
     "gemini-3.5-flash",
     "gemini-3-flash-preview",
     "gemini-2.5-computer-use-preview-10-2025",

--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -88,6 +88,7 @@ CuaLlm = Literal[
 GeminiComputerUseLlm = Literal[
     "gemini-3.6-flash",
     "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
     "gemini-3-flash-preview",
     "gemini-2.5-computer-use-preview-10-2025",
 ]

--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -87,7 +87,6 @@ CuaLlm = Literal[
 ]
 GeminiComputerUseLlm = Literal[
     "gemini-3.6-flash",
-    "gemini-3.5-flash-lite",
     "gemini-3.5-flash",
     "gemini-3-flash-preview",
     "gemini-2.5-computer-use-preview-10-2025",


### PR DESCRIPTION
## Summary
Adds `gemini-3.6-flash` and `gemini-3.5-flash-lite` to the `GeminiComputerUseLlm` literal type.

## Changes
- `hyperbrowser/models/consts.py`: expanded `GeminiComputerUseLlm`

## Validation
- `poetry run ruff check hyperbrowser/models/consts.py` ✅
- `poetry build` ✅


Link to Devin session: https://app.devin.ai/sessions/ca22b203b89844a0a119b73600d0efe7
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file Literal type expansion with no auth, data, or execution-path changes; worst case is SDK/type validation accepting new model strings the API may or may not support.
> 
> **Overview**
> Expands the **`GeminiComputerUseLlm`** type in `hyperbrowser/models/consts.py` so Gemini computer-use task params can select two additional model IDs: **`gemini-3.6-flash`** and **`gemini-3.5-flash-lite`**.
> 
> This is a typing-only change to the allowed `llm` values on **`StartGeminiComputerUseTaskParams`**; no runtime or API client logic is modified in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee70b575f5ada53ef9e06055532762d10744e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->