### PR TITLE
chore: bump version to 0.93.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.93.2"
+version = "0.93.3"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Bumps the Python SDK patch version to prepare for release after adding the new Gemini CUA model options.

## Changes
- `pyproject.toml`: version `0.93.2` → `0.93.3`

## Validation
- `poetry build` ✅


Link to Devin session: https://app.devin.ai/sessions/ca22b203b89844a0a119b73600d0efe7
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no code or dependency changes in this diff.
> 
> **Overview**
> Bumps the Poetry package version in `pyproject.toml` from **0.93.2** to **0.93.3** so the next SDK release is tagged correctly (e.g. after Gemini CUA-related changes landed elsewhere).
> 
> This PR does not change library code—only the published version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae6a64400695afb52273362a1e1d1b517071ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->