### PR TITLE
feat: add Claude Opus 5 to Claude computer use models

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -65,6 +65,7 @@ HyperAgentLlm = Literal[
     "gemini-3-flash-preview",
 ]
 ClaudeComputerUseLlm = Literal[
+    "claude-opus-5",
     "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-opus-4-7",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperbrowser"
-version = "0.93.3"
+version = "0.93.4"
 description = "Python SDK for hyperbrowser"
 authors = ["Nikhil Shahi <nshahi1998@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Adds `claude-opus-5` to the `ClaudeComputerUseLlm` Literal so the Python SDK accepts Claude Opus 5 for the claude-computer-use agent API (mirrors browserctrl#1256).

## Changes
- `hyperbrowser/models/consts.py`: add `"claude-opus-5"` to the `ClaudeComputerUseLlm` Literal.

## Validation
- `poetry run ruff check hyperbrowser/models/consts.py`

Link to Devin session: https://app.devin.ai/sessions/56c4640a2f94473897fafe2b0af34244
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only expansion of an allowed model id plus a patch version bump; no runtime logic or security-sensitive changes.
> 
> **Overview**
> Adds **`claude-opus-5`** to the `ClaudeComputerUseLlm` type in `hyperbrowser/models/consts.py`, so callers can pass that model on Claude computer-use task params (e.g. `StartClaudeComputerUseTaskParams.llm`) without type-checker complaints.
> 
> Bumps the package version to **0.93.4** in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 950a34469cc7da699fd0ae5c6a19e509d82ed121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->