### PR TITLE
feat: add Gemini 3.7 Flash to Gemini CUA and HyperAgent

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -62,6 +62,7 @@ HyperAgentLlm = Literal[
     "claude-sonnet-4-6",
     "claude-sonnet-4-5",
     "gemini-2.5-flash",
+    "gemini-3.7-flash",
     "gemini-3-flash-preview",
 ]
 ClaudeComputerUseLlm = Literal[
@@ -87,6 +88,7 @@ CuaLlm = Literal[
     "gpt-5.4-mini",
 ]
 GeminiComputerUseLlm = Literal[
+    "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash",
     "gemini-3.5-flash-lite",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `gemini-3.7-flash` to the Gemini Computer Use and HyperAgent LLM literals so the Python SDK matches [browserctrl#1310](https://github.com/hyperbrowserai/browserctrl/pull/1310).

## Changes
- `hyperbrowser/models/consts.py`: added `gemini-3.7-flash` to `GeminiComputerUseLlm` and `HyperAgentLlm`

## Validation
- `poetry run ruff check hyperbrowser/models/consts.py` — passed
- `poetry run ruff format --check hyperbrowser/models/consts.py` — passed
- `poetry run pytest tests --ignore=tests/sandbox/e2e` — 133 passed, 4 skipped
- Confirmed `StartGeminiComputerUseTaskParams` and `StartHyperAgentTaskParams` accept `llm="gemini-3.7-flash"`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef3c4462-48ec-4ead-bcfe-4f34b1ec7650?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef3c4462-48ec-4ead-bcfe-4f34b1ec7650&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

