### PR TITLE
Add volumes.delete for DELETE /volume/:key

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ sandbox = client.sandboxes.create(
 )
 
 sandbox.stop()
+client.volumes.delete(same_volume.id)
 client.close()
 ```
 

--- a/hyperbrowser/client/managers/async_manager/volume.py
+++ b/hyperbrowser/client/managers/async_manager/volume.py
@@ -4,6 +4,7 @@ from hyperbrowser.client._request import dump_request
 from hyperbrowser.models.volume import (
     CreateVolumeParams,
     Volume,
+    VolumeDeleteResult,
     VolumeListParams,
     VolumeListResponse,
 )
@@ -43,3 +44,9 @@ class VolumeManager:
             self._client._build_url(f"/volume/{volume_id}")
         )
         return Volume(**response.data)
+
+    async def delete(self, volume_id: str) -> VolumeDeleteResult:
+        response = await self._client.transport.delete(
+            self._client._build_url(f"/volume/{volume_id}")
+        )
+        return VolumeDeleteResult(**response.data)

--- a/hyperbrowser/client/managers/async_manager/volume.py
+++ b/hyperbrowser/client/managers/async_manager/volume.py
@@ -46,6 +46,7 @@ class VolumeManager:
         return Volume(**response.data)
 
     async def delete(self, volume_id: str) -> VolumeDeleteResult:
+        """Delete a volume by id or name. Ambiguous names and active mounts return 409."""
         response = await self._client.transport.delete(
             self._client._build_url(f"/volume/{volume_id}")
         )

--- a/hyperbrowser/client/managers/sync_manager/volume.py
+++ b/hyperbrowser/client/managers/sync_manager/volume.py
@@ -46,6 +46,7 @@ class VolumeManager:
         return Volume(**response.data)
 
     def delete(self, volume_id: str) -> VolumeDeleteResult:
+        """Delete a volume by id or name. Ambiguous names and active mounts return 409."""
         response = self._client.transport.delete(
             self._client._build_url(f"/volume/{volume_id}")
         )

--- a/hyperbrowser/client/managers/sync_manager/volume.py
+++ b/hyperbrowser/client/managers/sync_manager/volume.py
@@ -4,6 +4,7 @@ from hyperbrowser.client._request import dump_request
 from hyperbrowser.models.volume import (
     CreateVolumeParams,
     Volume,
+    VolumeDeleteResult,
     VolumeListParams,
     VolumeListResponse,
 )
@@ -43,3 +44,9 @@ class VolumeManager:
             self._client._build_url(f"/volume/{volume_id}")
         )
         return Volume(**response.data)
+
+    def delete(self, volume_id: str) -> VolumeDeleteResult:
+        response = self._client.transport.delete(
+            self._client._build_url(f"/volume/{volume_id}")
+        )
+        return VolumeDeleteResult(**response.data)

--- a/hyperbrowser/models/__init__.py
+++ b/hyperbrowser/models/__init__.py
@@ -210,7 +210,13 @@ from .profile import (
     ProfileListResponse,
     ProfileResponse,
 )
-from .volume import CreateVolumeParams, Volume, VolumeListParams, VolumeListResponse
+from .volume import (
+    CreateVolumeParams,
+    Volume,
+    VolumeDeleteResult,
+    VolumeListParams,
+    VolumeListResponse,
+)
 from .scrape import (
     BatchScrapeJobResponse,
     BatchScrapeJobStatusResponse,
@@ -537,6 +543,7 @@ __all__ = [
     "Volume",
     "VolumeListParams",
     "VolumeListResponse",
+    "VolumeDeleteResult",
     # scrape
     "BatchScrapeJobResponse",
     "BatchScrapeJobStatusResponse",

--- a/hyperbrowser/models/volume.py
+++ b/hyperbrowser/models/volume.py
@@ -36,3 +36,9 @@ class VolumeListResponse(VolumeBaseModel):
     total_count: Optional[int] = Field(default=None, alias="totalCount")
     page: Optional[int] = None
     per_page: Optional[int] = Field(default=None, alias="perPage")
+
+
+class VolumeDeleteResult(VolumeBaseModel):
+    deleted: bool
+    id: Optional[str] = None
+    name: Optional[str] = None

--- a/tests/test_volume_wire_contract.py
+++ b/tests/test_volume_wire_contract.py
@@ -4,7 +4,12 @@ from hyperbrowser.client.managers.async_manager.volume import (
     VolumeManager as AsyncVolumeManager,
 )
 from hyperbrowser.client.managers.sync_manager.volume import VolumeManager
-from hyperbrowser.models import CreateVolumeParams, Volume, VolumeListParams
+from hyperbrowser.models import (
+    CreateVolumeParams,
+    Volume,
+    VolumeDeleteResult,
+    VolumeListParams,
+)
 
 
 VOLUME_PAYLOAD = {
@@ -24,6 +29,12 @@ VOLUME_LIST_PAYLOAD = {
     "totalCount": 1,
     "page": 1,
     "perPage": 20,
+}
+
+VOLUME_DELETE_PAYLOAD = {
+    "deleted": True,
+    "id": "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d",
+    "name": "project-cache",
 }
 
 
@@ -55,6 +66,10 @@ class RecordingSyncTransport:
             return StubResponse(VOLUME_DETAIL_PAYLOAD)
         return StubResponse({})
 
+    def delete(self, url):
+        self.calls.append({"method": "DELETE", "url": url})
+        return StubResponse(VOLUME_DELETE_PAYLOAD)
+
 
 class RecordingAsyncTransport:
     def __init__(self):
@@ -78,6 +93,10 @@ class RecordingAsyncTransport:
         if url.endswith(f"/volume/{VOLUME_DETAIL_PAYLOAD['id']}"):
             return StubResponse(VOLUME_DETAIL_PAYLOAD)
         return StubResponse({})
+
+    async def delete(self, url):
+        self.calls.append({"method": "DELETE", "url": url})
+        return StubResponse(VOLUME_DELETE_PAYLOAD)
 
 
 class FakeSyncClient:
@@ -131,10 +150,12 @@ def test_sync_volume_manager_uses_expected_wire_keys(use_legacy_model):
     created = manager.create(CreateVolumeParams(name="project-cache"))
     listed = manager.list(list_params)
     fetched = manager.get("2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
+    deleted = manager.delete("2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
 
     create_call = client.transport.calls[0]
     list_call = client.transport.calls[1]
     get_call = client.transport.calls[2]
+    delete_call = client.transport.calls[3]
 
     assert create_call["method"] == "POST"
     assert create_call["url"].endswith("/volume")
@@ -153,6 +174,13 @@ def test_sync_volume_manager_uses_expected_wire_keys(use_legacy_model):
     assert fetched.name == "project-cache"
     assert fetched.transfer_amount is None
 
+    assert delete_call["method"] == "DELETE"
+    assert delete_call["url"].endswith("/volume/2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
+    assert deleted.deleted is True
+    assert deleted.id == "2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d"
+    assert deleted.name == "project-cache"
+    assert isinstance(deleted, VolumeDeleteResult)
+
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("use_legacy_model", [False, True])
@@ -166,10 +194,12 @@ async def test_async_volume_manager_uses_expected_wire_keys(use_legacy_model):
     created = await manager.create({"name": "project-cache"})
     listed = await manager.list(list_params)
     fetched = await manager.get("2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
+    deleted = await manager.delete("2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
 
     create_call = client.transport.calls[0]
     list_call = client.transport.calls[1]
     get_call = client.transport.calls[2]
+    delete_call = client.transport.calls[3]
 
     assert create_call["method"] == "POST"
     assert create_call["url"].endswith("/volume")
@@ -185,6 +215,11 @@ async def test_async_volume_manager_uses_expected_wire_keys(use_legacy_model):
     assert get_call["url"].endswith("/volume/2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
     assert created.transfer_amount == 0
     assert fetched.name == "project-cache"
+
+    assert delete_call["method"] == "DELETE"
+    assert delete_call["url"].endswith("/volume/2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
+    assert deleted.deleted is True
+    assert deleted.name == "project-cache"
 
 
 def test_sync_volume_list_without_params_remains_supported():

--- a/tests/typecheck/valid_requests.py
+++ b/tests/typecheck/valid_requests.py
@@ -133,6 +133,7 @@ def valid_sync_requests(client: Hyperbrowser) -> None:
     )
     client.volumes.list({"page": 0, "limit": -1})
     client.volumes.list(LegacyVolumeListParams(page=0, limit=-1))
+    client.volumes.delete("2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
 
     client.sessions.create(LegacyCreateSessionParams(use_stealth=True, region="us"))
     client.web.fetch(LegacyFetchParams(url="https://example.com"))
@@ -198,6 +199,7 @@ async def valid_async_requests(client: AsyncHyperbrowser) -> None:
     )
     await client.sandboxes.list_image_builds({"status": "verifying", "limit": -1})
     await client.volumes.list({"page": 0, "limit": -1})
+    await client.volumes.delete("2d6f01cf-c5d7-4c61-ae9e-0264f1c8063d")
 
     await client.sessions.create(LegacyCreateSessionParams(use_proxy=True, region="us"))
     await client.web.fetch(LegacyFetchParams(url="https://example.com"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds `volumes.delete()` for `DELETE /volume/:key`.

## Changes
- Sync and async `VolumeManager.delete(volume_id)`
- `VolumeDeleteResult` includes `deleted`, `id`, and `name`
- Documents 409s for ambiguous names and active mounts

## Validation
- `poetry run pytest tests/test_volume_wire_contract.py` — 8 passed
- `poetry run ruff check` on the touched volume managers — pass

Companion: [browserctrl#1311](https://github.com/hyperbrowserai/browserctrl/pull/1311)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b624b5b9-60c2-4f9a-8f41-76712aea998c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b624b5b9-60c2-4f9a-8f41-76712aea998c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

