### PR TITLE
Add gemini-3.8-flash to Gemini CUA, HyperAgent, and Browser Use LLM types

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -45,6 +45,7 @@ BrowserUseLlm = Literal[
     "claude-3-5-haiku-20241022",
     "gemini-2.0-flash",
     "gemini-2.5-flash",
+    "gemini-3.8-flash",
 ]
 HyperAgentLlm = Literal[
     "gpt-5.6-luna",
@@ -62,6 +63,7 @@ HyperAgentLlm = Literal[
     "claude-sonnet-4-6",
     "claude-sonnet-4-5",
     "gemini-2.5-flash",
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3-flash-preview",
 ]
@@ -88,6 +90,7 @@ CuaLlm = Literal[
     "gpt-5.4-mini",
 ]
 GeminiComputerUseLlm = Literal[
+    "gemini-3.8-flash",
     "gemini-3.7-flash",
     "gemini-3.6-flash",
     "gemini-3.5-flash",


### PR DESCRIPTION
## Summary
Adds `"gemini-3.8-flash"` to `GeminiComputerUseLlm`, `HyperAgentLlm`, and `BrowserUseLlm` literals. Server support: hyperbrowserai/browserctrl#1385 (it is now the server-side default for Gemini Computer Use).

## Changes
- `hyperbrowser/models/consts.py`: new `"gemini-3.8-flash"` entry in the three LLM `Literal`s.

## Validation
- Syntax-checked; `ruff` not installed in this environment (constants-only change).

Link to Devin session: https://app.devin.ai/sessions/7dccc05e05b04c63bd5760859b161275
Open in Devin Desktop: https://app.devin.ai/desktop/session/7dccc05e05b04c63bd5760859b161275?variant=devin
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constants-only expansion of allowed model strings; no runtime logic changes.
> 
> **Overview**
> Adds **`gemini-3.8-flash`** to three LLM `Literal` types in `hyperbrowser/models/consts.py`: `BrowserUseLlm`, `HyperAgentLlm`, and `GeminiComputerUseLlm`.
> 
> This lets the Python SDK accept and type-check that model id on Browser Use, HyperAgent, and Gemini Computer Use agent options (e.g. `llm` fields), matching server support where it is now the default for Gemini Computer Use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48a7ec1be6118d3f8ee5f886743b6ebe85def8cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->