### PR TITLE
Add gpt-6-astra to CuaLlm

### DIFF
--- a/hyperbrowser/models/consts.py
+++ b/hyperbrowser/models/consts.py
@@ -83,6 +83,7 @@ ClaudeComputerUseLlm = Literal[
 ]
 CuaLlm = Literal[
     "computer-use-preview",
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",


### PR DESCRIPTION
## Summary
Add OpenAI's `gpt-6-astra` to the `CuaLlm` literal so it can be passed as `llm` to the OpenAI CUA agent. Server side: hyperbrowserai/browserctrl#1396.

## Changes
- `CuaLlm` in `hyperbrowser/models/consts.py`: add `"gpt-6-astra"`

## Validation
- `python -m py_compile hyperbrowser/models/consts.py` (poetry not installed in this env; relying on CI for `ruff check` / `pytest`)


Link to Devin session: https://app.devin.ai/sessions/ab85ce2ee8684fe5963e6b391e840f02
Open in Devin Desktop: https://app.devin.ai/desktop/session/ab85ce2ee8684fe5963e6b391e840f02?variant=devin
Requested by: @shrisukhani

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single new string in a `Literal` type with no runtime logic changes in this repo.
> 
> **Overview**
> Adds **`gpt-6-astra`** to the `CuaLlm` type literal in `hyperbrowser/models/consts.py`, so clients can pass that model id as `llm` on OpenAI CUA task creation (`StartCuaTaskParams`).
> 
> This is a typing/SDK allowlist change only; backend support is handled separately (browserctrl#1396).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3498297078b171d713418654374c4a8c5b7a3dc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->